### PR TITLE
Only consider subexpressions of the starting expression for CSE.

### DIFF
--- a/src/Language/Syntactic/Sharing/SimpleCodeMotion.hs
+++ b/src/Language/Syntactic/Sharing/SimpleCodeMotion.hs
@@ -125,7 +125,7 @@ choose :: forall dom a
     -> MkInjDict dom
     -> ASTF dom a
     -> Maybe (Chosen dom a)
-choose hoistOver pd mkId a = chooseEnv initEnv a
+choose hoistOver pd mkId a = chooseEnvSub initEnv a
   where
     initEnv = Env
         { inLambda     = False


### PR DESCRIPTION
The current CSE will consider the input expression itself before traversing into subexpressions. The reason the CSE does not loop is because the heuristic will prevent CSE since there is only one expression according to the counter (the expression itself).
