### PR TITLE
Specialize instances

### DIFF
--- a/examples/NanoFeldspar/Core.hs
+++ b/examples/NanoFeldspar/Core.hs
@@ -44,7 +44,8 @@ import Language.Syntactic.Sharing.CodeMotion2
 
 -- | Convenient class alias
 class    (Ord a, Show a, Typeable a) => Type a
-instance (Ord a, Show a, Typeable a) => Type a
+instance (Ord a, Show a, Typeable a) => Type a where
+  {-# SPECIALIZE instance (Ord a, Show a, Typeable a) => Type a #-}
 
 type Length = Int
 type Index  = Int
@@ -61,11 +62,15 @@ data Parallel a
 
 instance Constrained Parallel
   where
+    {-# SPECIALIZE instance Constrained Parallel #-}
+    {-# INLINABLE exprDict #-}
     type Sat Parallel = Type
     exprDict Parallel = Dict
 
 instance Semantic Parallel
   where
+    {-# SPECIALIZE instance Semantic Parallel #-}
+    {-# INLINABLE semantics #-}
     semantics Parallel = Sem
         { semanticName = "parallel"
         , semanticEval = \len ixf -> map ixf [0 .. len-1]
@@ -73,11 +78,13 @@ instance Semantic Parallel
 
 semanticInstances ''Parallel
 
-instance EvalBind Parallel where evalBindSym = evalBindSymDefault
+instance EvalBind Parallel where
+  {-# SPECIALIZE instance EvalBind Parallel #-}
 
 instance AlphaEq dom dom dom env => AlphaEq Parallel Parallel dom env
   where
-    alphaEqSym = alphaEqSymDefault
+    {-# SPECIALIZE instance AlphaEq dom dom dom env =>
+          AlphaEq Parallel Parallel dom env #-}
 
 
 
@@ -274,4 +281,3 @@ max = sugarSymC $ Construct "max" Prelude.max
 
 min :: Type a => Data a -> Data a -> Data a
 min = sugarSymC $ Construct "min" Prelude.min
-

--- a/examples/NanoFeldspar/Extra.hs
+++ b/examples/NanoFeldspar/Extra.hs
@@ -64,10 +64,14 @@ drawObs a = do
 
 instance Optimize ForLoop
   where
+    {-# SPECIALIZE instance Optimize ForLoop #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym = optimizeSymDefault
 
 instance Optimize Parallel
   where
+    {-# SPECIALIZE instance Optimize Parallel #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym = optimizeSymDefault
 
 constFold :: forall a
@@ -90,4 +94,3 @@ reifySimp = flip evalState 0 .
 
 drawSimp :: (Syntactic a, Domain a ~ FeldDomainAll) => a -> IO ()
 drawSimp = Syntactic.drawAST . reifySimp
-

--- a/examples/NanoFeldspar/Vector.hs
+++ b/examples/NanoFeldspar/Vector.hs
@@ -33,6 +33,9 @@ data Vector a
 
 instance Syntax a => Syntactic (Vector a)
   where
+    {-# SPECIALIZE instance Syntax a => Syntactic (Vector a) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (Vector a)   = FeldDomainAll
     type Internal (Vector a) = [Internal a]
     desugar = desugar . freezeVector . map resugar
@@ -96,4 +99,3 @@ type Matrix a = Vector (Vector (Data a))
 -- | Transpose of a matrix. Assumes that the number of rows is > 0.
 transpose :: Type a => Matrix a -> Matrix a
 transpose a = indexed (length (a!0)) $ \k -> indexed (length a) $ \l -> a ! l ! k
-

--- a/src/Language/Syntactic.hs
+++ b/src/Language/Syntactic.hs
@@ -6,6 +6,7 @@ module Language.Syntactic
     , module Language.Syntactic.Traversal
     , module Language.Syntactic.Constraint
     , module Language.Syntactic.Sugar
+    , module Language.Syntactic.Interpretation
     , module Language.Syntactic.Interpretation.Equality
     , module Language.Syntactic.Interpretation.Render
     , module Language.Syntactic.Interpretation.Evaluation
@@ -20,10 +21,10 @@ import Language.Syntactic.Syntax
 import Language.Syntactic.Traversal
 import Language.Syntactic.Constraint
 import Language.Syntactic.Sugar
+import Language.Syntactic.Interpretation
 import Language.Syntactic.Interpretation.Equality
 import Language.Syntactic.Interpretation.Render
 import Language.Syntactic.Interpretation.Evaluation
 import Language.Syntactic.Interpretation.Semantics
 
 import Data.Constraint (Constraint, Dict (..))
-

--- a/src/Language/Syntactic/Constraint.hs
+++ b/src/Language/Syntactic/Constraint.hs
@@ -27,19 +27,23 @@ import Language.Syntactic.Interpretation.Evaluation
 
 -- | Intersection of type predicates
 class    (c1 a, c2 a) => (c1 :/\: c2) a
-instance (c1 a, c2 a) => (c1 :/\: c2) a
+instance (c1 a, c2 a) => (c1 :/\: c2) a where
+  {-# SPECIALIZE instance (c1 a, c2 a) => (c1 :/\: c2) a #-}
 
 infixr 5 :/\:
 
 -- | Universal type predicate
 class    Top a
-instance Top a
+instance Top a where
+  {-# SPECIALIZE instance Top a #-}
 
 pTop :: P Top
 pTop = P
+{-# INLINABLE pTop #-}
 
 pTypeable :: P Typeable
 pTypeable = P
+{-# INLINABLE pTypeable #-}
 
 -- | Evidence that the predicate @sub@ is a subset of @sup@
 type Sub sub sup = forall a . Dict (sub a) -> Dict (sup a)
@@ -47,10 +51,12 @@ type Sub sub sup = forall a . Dict (sub a) -> Dict (sup a)
 -- | Weaken an intersection
 weakL :: Sub (c1 :/\: c2) c1
 weakL Dict = Dict
+{-# INLINABLE weakL #-}
 
 -- | Weaken an intersection
 weakR :: Sub (c1 :/\: c2) c2
 weakR Dict = Dict
+{-# INLINABLE weakR #-}
 
 -- | Subset relation on type predicates
 class (sub :: * -> Constraint) :< (sup :: * -> Constraint)
@@ -61,14 +67,20 @@ class (sub :: * -> Constraint) :< (sup :: * -> Constraint)
 
 instance p :< p
   where
+    {-# SPECIALIZE instance p :< p #-}
+    {-# INLINABLE sub #-}
     sub = id
 
 instance (p :/\: ps) :< p
   where
+    {-# SPECIALIZE instance (p :/\: ps) :< p #-}
+    {-# INLINABLE sub #-}
     sub = weakL
 
 instance (ps :< q) => ((p :/\: ps) :< q)
   where
+    {-# SPECIALIZE instance (ps :< q) => ((p :/\: ps) :< q) #-}
+    {-# INLINABLE sub #-}
     sub = sub . weakR
 
 
@@ -86,24 +98,36 @@ infixl 4 :|
 
 instance Project sub sup => Project sub (sup :| pred)
   where
+    {-# SPECIALIZE instance (Project sub sup) => Project sub (sup :| pred) #-}
+    {-# INLINABLE prj #-}
     prj (C s) = prj s
 
 instance Equality dom => Equality (dom :| pred)
   where
+    {-# SPECIALIZE instance (Equality dom) => Equality (dom :| pred) #-}
+    {-# INLINABLE equal #-}
+    {-# INLINABLE exprHash #-}
     equal (C a) (C b) = equal a b
     exprHash (C a)    = exprHash a
 
 instance Render dom => Render (dom :| pred)
   where
+    {-# SPECIALIZE instance (Render dom) => Render (dom :| pred) #-}
+    {-# INLINABLE renderSym #-}
+    {-# INLINABLE renderArgs #-}
     renderSym (C a) = renderSym a
     renderArgs args (C a) = renderArgs args a
 
 instance Eval dom => Eval (dom :| pred)
   where
+    {-# SPECIALIZE instance (Eval dom) => Eval (dom :| pred) #-}
+    {-# INLINABLE evaluate #-}
     evaluate (C a) = evaluate a
 
 instance StringTree dom => StringTree (dom :| pred)
   where
+    {-# SPECIALIZE instance (StringTree dom) => StringTree (dom :| pred) #-}
+    {-# INLINABLE stringTreeSym #-}
     stringTreeSym args (C a) = stringTreeSym args a
 
 
@@ -123,24 +147,36 @@ infixl 4 :||
 
 instance Project sub sup => Project sub (sup :|| pred)
   where
+    {-# SPECIALIZE instance (Project sub sup) => Project sub (sup :|| pred) #-}
+    {-# INLINABLE prj #-}
     prj (C' s) = prj s
 
 instance Equality dom => Equality (dom :|| pred)
   where
+    {-# SPECIALIZE instance (Equality dom) => Equality (dom :|| pred) #-}
+    {-# INLINABLE equal #-}
+    {-# INLINABLE exprHash #-}
     equal (C' a) (C' b) = equal a b
     exprHash (C' a)     = exprHash a
 
 instance Render dom => Render (dom :|| pred)
   where
+    {-# SPECIALIZE instance (Render dom) => Render (dom :|| pred) #-}
+    {-# INLINABLE renderSym #-}
+    {-# INLINABLE renderArgs #-}
     renderSym (C' a) = renderSym a
     renderArgs args (C' a) = renderArgs args a
 
 instance Eval dom => Eval (dom :|| pred)
   where
+    {-# SPECIALIZE instance (Eval dom) => Eval (dom :|| pred) #-}
+    {-# INLINABLE evaluate #-}
     evaluate (C' a) = evaluate a
 
 instance StringTree dom => StringTree (dom :|| pred)
   where
+    {-# SPECIALIZE instance (StringTree dom) => StringTree (dom :|| pred) #-}
+    {-# INLINABLE stringTreeSym #-}
     stringTreeSym args (C' a) = stringTreeSym args a
 
 
@@ -157,33 +193,42 @@ class Constrained expr
 
 instance Constrained dom => Constrained (AST dom)
   where
+    {-# SPECIALIZE instance (Constrained dom) => Constrained (AST dom) #-}
+    {-# INLINABLE exprDict #-}
     type Sat (AST dom) = Sat dom
     exprDict (Sym s)  = exprDict s
     exprDict (s :$ _) = exprDict s
 
 instance Constrained (sub1 :+: sub2)
   where
+    {-# SPECIALIZE instance (Constrained (sub1 :+: sub2)) #-}
+    {-# INLINABLE exprDict #-}
     -- | An over-approximation of the union of @Sat sub1@ and @Sat sub2@
     type Sat (sub1 :+: sub2) = Top
-    exprDict (InjL s) = Dict
-    exprDict (InjR s) = Dict
+    exprDict (InjL _) = Dict
+    exprDict (InjR _) = Dict
 
 instance Constrained dom => Constrained (dom :| pred)
   where
+    {-# SPECIALIZE instance (Constrained dom) => Constrained (dom :| pred) #-}
+    {-# INLINABLE exprDict #-}
     type Sat (dom :| pred) = pred :/\: Sat dom
     exprDict (C s) = case exprDict s of Dict -> Dict
 
 instance Constrained (dom :|| pred)
   where
+    {-# SPECIALIZE instance Constrained (dom :|| pred) #-}
+    {-# INLINABLE exprDict #-}
     type Sat (dom :|| pred) = pred
-    exprDict (C' s) = Dict
+    exprDict (C' _) = Dict
 
 type ConstrainedBy expr p = (Constrained expr, Sat expr :< p)
 
 -- | A version of 'exprDict' that returns a constraint for a particular
 -- predicate @p@ as long as @(p :< Sat dom)@ holds
 exprDictSub :: ConstrainedBy expr p => P p -> expr a -> Dict (p (DenResult a))
-exprDictSub _ = sub . exprDict
+exprDictSub = const $ sub . exprDict
+{-# INLINABLE exprDictSub #-}
 
 -- | A version of 'exprDict' that works for domains of the form
 -- @(dom1 :+: dom2)@ as long as @(Sat dom1 ~ Sat dom2)@ holds
@@ -192,6 +237,7 @@ exprDictPlus :: (Constrained dom1, Constrained dom2, Sat dom1 ~ Sat dom2) =>
 exprDictPlus (s :$ _)       = exprDictPlus s
 exprDictPlus (Sym (InjL a)) = exprDict a
 exprDictPlus (Sym (InjR a)) = exprDict a
+{-# INLINABLE exprDictPlus #-}
 
 
 
@@ -200,28 +246,40 @@ class (Project sub sup, Sat sup a) => InjectC sub sup a
   where
     injC :: (DenResult sig ~ a) => sub sig -> sup sig
 
-instance InjectC sub sup a => InjectC sub (AST sup) a
+instance (InjectC sub sup a, Sat (AST sup) a) => InjectC sub (AST sup) a
   where
+    {-# SPECIALIZE instance (InjectC sub sup a, Sat (AST sup) a) => InjectC sub (AST sup) a #-}
+    {-# INLINABLE injC #-}
     injC = Sym . injC
 
-instance (InjectC sub sup a, pred a) => InjectC sub (sup :| pred) a
+instance (InjectC sub sup a, Sat (sup :| pred) a) => InjectC sub (sup :| pred) a
   where
+    {-# SPECIALIZE instance (InjectC sub sup a, Sat (sup :| pred) a) => InjectC sub (sup :| pred) a #-}
+    {-# INLINABLE injC #-}
     injC = C . injC
 
-instance (InjectC sub sup a, pred a) => InjectC sub (sup :|| pred) a
+instance (InjectC sub sup a, Sat (sup :|| pred) a) => InjectC sub (sup :|| pred) a
   where
+    {-# SPECIALIZE instance (InjectC sub sup a, Sat (sup :|| pred) a) => InjectC sub (sup :|| pred) a #-}
+    {-# INLINABLE injC #-}
     injC = C' . injC
 
 instance Sat expr a => InjectC expr expr a
   where
+    {-# SPECIALIZE instance Sat expr a => InjectC expr expr a #-}
+    {-# INLINABLE injC #-}
     injC = id
 
 instance InjectC expr1 (expr1 :+: expr2) a
   where
+    {-# SPECIALIZE instance InjectC expr1 (expr1 :+: expr2) a #-}
+    {-# INLINABLE injC #-}
     injC = InjL
 
 instance InjectC expr1 expr3 a => InjectC expr1 (expr2 :+: expr3) a
   where
+    {-# SPECIALIZE instance InjectC expr1 expr3 a => InjectC expr1 (expr2 :+: expr3) a #-}
+    {-# INLINABLE injC #-}
     injC = InjR . injC
 
 
@@ -235,6 +293,7 @@ instance InjectC expr1 expr3 a => InjectC expr1 (expr2 :+: expr3) a
 -- >     -> (ASTF dom a -> ASTF dom b -> ... -> ASTF dom x)
 appSymC :: (ApplySym sig f dom, InjectC sym (AST dom) (DenResult sig)) => sym sig -> f
 appSymC = appSym' . injC
+{-# INLINABLE appSymC #-}
 
 
 
@@ -246,29 +305,43 @@ data SubConstr1 :: (* -> *) -> (* -> *) -> (* -> Constraint) -> (* -> *)
 
 instance Constrained dom => Constrained (SubConstr1 c dom p)
   where
+    {-# SPECIALIZE instance Constrained dom => Constrained (SubConstr1 c dom p) #-}
+    {-# INLINABLE exprDict #-}
     type Sat (SubConstr1 c dom p) = Sat dom
     exprDict (SubConstr1 s) = exprDict s
 
 instance Project sub sup => Project sub (SubConstr1 c sup p)
   where
+    {-# SPECIALIZE instance Project sub sup => Project sub (SubConstr1 c sup p) #-}
+    {-# INLINABLE prj #-}
     prj (SubConstr1 s) = prj s
 
 instance Equality dom => Equality (SubConstr1 c dom p)
   where
+    {-# SPECIALIZE instance Equality dom => Equality (SubConstr1 c dom p) #-}
+    {-# INLINABLE equal #-}
+    {-# INLINABLE exprHash #-}
     equal (SubConstr1 a) (SubConstr1 b) = equal a b
     exprHash (SubConstr1 s) = exprHash s
 
 instance Render dom => Render (SubConstr1 c dom p)
   where
+    {-# SPECIALIZE instance Render dom => Render (SubConstr1 c dom p) #-}
+    {-# INLINABLE renderSym #-}
+    {-# INLINABLE renderArgs #-}
     renderSym (SubConstr1 s) = renderSym s
     renderArgs args (SubConstr1 s) = renderArgs args s
 
 instance StringTree dom => StringTree (SubConstr1 c dom p)
   where
+    {-# SPECIALIZE instance StringTree dom => StringTree (SubConstr1 c dom p) #-}
+    {-# INLINABLE stringTreeSym #-}
     stringTreeSym args (SubConstr1 a) = stringTreeSym args a
 
 instance Eval dom => Eval (SubConstr1 c dom p)
   where
+    {-# SPECIALIZE instance Eval dom => Eval (SubConstr1 c dom p) #-}
+    {-# INLINABLE evaluate #-}
     evaluate (SubConstr1 a) = evaluate a
 
 
@@ -281,29 +354,43 @@ data SubConstr2 :: (* -> * -> *) -> (* -> *) -> (* -> Constraint) -> (* -> Const
 
 instance Constrained dom => Constrained (SubConstr2 c dom pa pb)
   where
+    {-# SPECIALIZE instance Constrained dom => Constrained (SubConstr2 c dom pa pb) #-}
+    {-# INLINABLE exprDict #-}
     type Sat (SubConstr2 c dom pa pb) = Sat dom
     exprDict (SubConstr2 s) = exprDict s
 
 instance Project sub sup => Project sub (SubConstr2 c sup pa pb)
   where
+    {-# SPECIALIZE instance Project sub sup => Project sub (SubConstr2 c sup pa pb) #-}
+    {-# INLINABLE prj #-}
     prj (SubConstr2 s) = prj s
 
 instance Equality dom => Equality (SubConstr2 c dom pa pb)
   where
+    {-# SPECIALIZE instance Equality dom => Equality (SubConstr2 c dom pa pb) #-}
+    {-# INLINABLE equal #-}
+    {-# INLINABLE exprHash #-}
     equal (SubConstr2 a) (SubConstr2 b) = equal a b
     exprHash (SubConstr2 s) = exprHash s
 
 instance Render dom => Render (SubConstr2 c dom pa pb)
   where
+    {-# SPECIALIZE instance Render dom => Render (SubConstr2 c dom pa pb) #-}
+    {-# INLINABLE renderSym #-}
+    {-# INLINABLE renderArgs #-}
     renderSym (SubConstr2 s) = renderSym s
     renderArgs args (SubConstr2 s) = renderArgs args s
 
 instance StringTree dom => StringTree (SubConstr2 c dom pa pb)
   where
+    {-# SPECIALIZE instance StringTree dom => StringTree (SubConstr2 c dom pa pb) #-}
+    {-# INLINABLE stringTreeSym #-}
     stringTreeSym args (SubConstr2 a) = stringTreeSym args a
 
 instance Eval dom => Eval (SubConstr2 c dom pa pb)
   where
+    {-# SPECIALIZE instance Eval dom => Eval (SubConstr2 c dom pa pb) #-}
+    {-# INLINABLE evaluate #-}
     evaluate (SubConstr2 a) = evaluate a
 
 
@@ -322,11 +409,13 @@ liftASTE
     -> ASTE dom
     -> b
 liftASTE f (ASTE a) = f a
+{-# INLINABLE liftASTE #-}
 
 liftASTE2
     :: (forall a b . ASTF dom a -> ASTF dom b -> c)
     -> ASTE dom -> ASTE dom -> c
 liftASTE2 f (ASTE a) (ASTE b) = f a b
+{-# INLINABLE liftASTE2 #-}
 
 
 
@@ -340,11 +429,13 @@ liftASTB
     -> ASTB dom p
     -> b
 liftASTB f (ASTB a) = f a
+{-# INLINABLE liftASTB #-}
 
 liftASTB2
     :: (forall a b . (p a, p b) => ASTF dom a -> ASTF dom b -> c)
     -> ASTB dom p -> ASTB dom p -> c
 liftASTB2 f (ASTB a) (ASTB b) = f a b
+{-# INLINABLE liftASTB2 #-}
 
 type ASTSAT dom = ASTB dom (Sat dom)
 
@@ -375,15 +466,23 @@ data Empty :: * -> *
 
 instance Constrained Empty
   where
+    {-# SPECIALIZE instance Constrained Empty #-}
     type Sat Empty = Top
     exprDict = error "Not implemented: exprDict for Empty"
 
-instance Equality   Empty where equal      = error "Not implemented: equal for Empty"
-                                exprHash   = error "Not implemented: exprHash for Empty"
-instance Eval       Empty where evaluate   = error "Not implemented: equal for Empty"
-instance Render     Empty where renderSym  = error "Not implemented: renderSym for Empty"
-                                renderArgs = error "Not implemented: renderArgs for Empty"
-instance StringTree Empty
+instance Equality Empty where
+  {-# SPECIALIZE instance Equality Empty #-}
+  equal      = error "Not implemented: equal for Empty"
+  exprHash   = error "Not implemented: exprHash for Empty"
+instance Eval Empty where
+  {-# SPECIALIZE instance Eval Empty #-}
+  evaluate   = error "Not implemented: equal for Empty"
+instance Render Empty where
+  {-# SPECIALIZE instance Render Empty #-}
+  renderSym  = error "Not implemented: renderSym for Empty"
+  renderArgs = error "Not implemented: renderArgs for Empty"
+instance StringTree Empty where
+  {-# SPECIALIZE instance StringTree Empty #-}
 
 
 

--- a/src/Language/Syntactic/Constraint.hs
+++ b/src/Language/Syntactic/Constraint.hs
@@ -391,6 +391,5 @@ universe :: ASTF dom a -> [ASTE dom]
 universe a = ASTE a : go a
   where
     go :: AST dom a -> [ASTE dom]
-    go (Sym s)  = []
-    go (s :$ a) = go s ++ universe a
-
+    go (Sym _)  = []
+    go (s :$ b) = go s ++ universe b

--- a/src/Language/Syntactic/Constructs/Binding/HigherOrder.hs
+++ b/src/Language/Syntactic/Constructs/Binding/HigherOrder.hs
@@ -55,6 +55,8 @@ class IsHODomain dom p pVar | dom -> p pVar
 
 instance IsHODomain (HODomain dom p pVar) p pVar
   where
+    {-# SPECIALIZE instance IsHODomain (HODomain dom p pVar) p pVar #-}
+    {-# INLINABLE lambda #-}
     lambda = injC . HOLambda
 
 instance
@@ -67,6 +69,15 @@ instance
     ) =>
       Syntactic (a -> b)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , IsHODomain dom p pVar
+                            , p (Internal a -> Internal b)
+                            , p (Internal a)
+                            , pVar (Internal a)
+                            ) => Syntactic (a -> b) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a -> b)   = Domain a
     type Internal (a -> b) = Internal a -> Internal b
     desugar f = lambda (desugar . f . sugar)
@@ -100,4 +111,3 @@ reifyTop = flip evalState 0 . reifyM
 reify :: (Syntactic a, Domain a ~ HODomain dom p pVar) =>
     a -> ASTF (FODomain dom p pVar) (Internal a)
 reify = reifyTop . desugar
-

--- a/src/Language/Syntactic/Constructs/Binding/Optimize.hs
+++ b/src/Language/Syntactic/Constructs/Binding/Optimize.hs
@@ -52,6 +52,8 @@ class Optimize sym
         -> sym sig
         -> Args (AST dom) sig
         -> Writer (Set VarId) (ASTF dom (DenResult sig))
+    optimizeSym = optimizeSymDefault
+    {-# INLINABLE optimizeSym #-}
 
   -- The reason for having @dom@ as a class parameter is that many instances
   -- need to put additional constraints on @dom@.
@@ -65,6 +67,9 @@ type Optimize' dom =
 
 instance (Optimize sub1, Optimize sub2) => Optimize (sub1 :+: sub2)
   where
+    {-# SPECIALIZE instance (Optimize sub1, Optimize sub2) =>
+          Optimize (sub1 :+: sub2) #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym constFold injecter (InjL a) = optimizeSym constFold (injecter . InjL) a
     optimizeSym constFold injecter (InjR a) = optimizeSym constFold (injecter . InjR) a
 
@@ -96,33 +101,45 @@ optimizeSymDefault constFold injecter sym args = do
 
 instance Optimize dom => Optimize (dom :| p)
   where
+    {-# SPECIALIZE instance Optimize dom => Optimize (dom :| p) #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym cf i (C s) args = optimizeSym cf (i . C) s args
 
 instance Optimize dom => Optimize (dom :|| p)
   where
+    {-# SPECIALIZE instance Optimize dom => Optimize (dom :|| p) #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym cf i (C' s) args = optimizeSym cf (i . C') s args
 
 instance Optimize Empty
   where
+    {-# SPECIALIZE instance Optimize Empty #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym = error "Not implemented: optimizeSym for Empty"
 
 instance Optimize dom => Optimize (SubConstr1 c dom p)
   where
+    {-# SPECIALIZE instance Optimize dom => Optimize (SubConstr1 c dom p) #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym cf i (SubConstr1 s) args = optimizeSym cf (i . SubConstr1) s args
 
 instance Optimize dom => Optimize (SubConstr2 c dom pa pb)
   where
+    {-# SPECIALIZE instance Optimize dom => Optimize (SubConstr2 c dom pa pb) #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym cf i (SubConstr2 s) args = optimizeSym cf (i . SubConstr2) s args
 
-instance Optimize Identity  where optimizeSym = optimizeSymDefault
-instance Optimize Construct where optimizeSym = optimizeSymDefault
-instance Optimize Literal   where optimizeSym = optimizeSymDefault
-instance Optimize Tuple     where optimizeSym = optimizeSymDefault
-instance Optimize Select    where optimizeSym = optimizeSymDefault
-instance Optimize Let       where optimizeSym = optimizeSymDefault
+instance Optimize Identity  where {-# SPECIALIZE instance Optimize Identity #-}
+instance Optimize Construct where {-# SPECIALIZE instance Optimize Construct #-}
+instance Optimize Literal   where {-# SPECIALIZE instance Optimize Literal #-}
+instance Optimize Tuple     where {-# SPECIALIZE instance Optimize Tuple #-}
+instance Optimize Select    where {-# SPECIALIZE instance Optimize Select #-}
+instance Optimize Let       where {-# SPECIALIZE instance Optimize Let #-}
 
 instance Optimize Condition
   where
+    {-# SPECIALIZE instance Optimize Condition #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym constFold injecter cond@Condition args@(c :* t :* e :* Nil)
         | Set.null cVars = optimizeM constFold t_or_e
         | alphaEq t e    = optimizeM constFold t
@@ -133,13 +150,16 @@ instance Optimize Condition
 
 instance Optimize Variable
   where
+    {-# SPECIALIZE instance Optimize Variable #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym _ injecter var@(Variable v) Nil = do
         tell (singleton v)
         return (injecter var)
 
 instance Optimize Lambda
   where
+    {-# SPECIALIZE instance Optimize Lambda #-}
+    {-# INLINABLE optimizeSym #-}
     optimizeSym constFold injecter lam@(Lambda v) (body :* Nil) = do
         body' <- censor (delete v) $ optimizeM constFold body
         return $ injecter lam :$ body'
-

--- a/src/Language/Syntactic/Constructs/Condition.hs
+++ b/src/Language/Syntactic/Constructs/Condition.hs
@@ -16,12 +16,15 @@ data Condition sig
 
 instance Constrained Condition
   where
+    {-# SPECIALIZE instance Constrained Condition #-}
+    {-# INLINABLE exprDict #-}
     type Sat Condition = Top
-    exprDict _ = Dict
+    exprDict = const Dict
 
 instance Semantic Condition
   where
+    {-# SPECIALIZE instance Semantic Condition #-}
+    {-# INLINABLE semantics #-}
     semantics Condition = Sem "condition" (\c t e -> if c then t else e)
 
 semanticInstances ''Condition
-

--- a/src/Language/Syntactic/Constructs/Construct.hs
+++ b/src/Language/Syntactic/Constructs/Construct.hs
@@ -19,12 +19,15 @@ data Construct sig
 
 instance Constrained Construct
   where
+    {-# SPECIALIZE instance Constrained Construct #-}
+    {-# INLINABLE exprDict #-}
     type Sat Construct = Top
-    exprDict _ = Dict
+    exprDict = const Dict
 
 instance Semantic Construct
   where
+    {-# SPECIALIZE instance Semantic Construct #-}
+    {-# INLINABLE semantics #-}
     semantics (Construct name den) = Sem name den
 
 semanticInstances ''Construct
-

--- a/src/Language/Syntactic/Constructs/Identity.hs
+++ b/src/Language/Syntactic/Constructs/Identity.hs
@@ -17,12 +17,15 @@ data Identity sig
 
 instance Constrained Identity
   where
+    {-# SPECIALIZE instance Constrained Identity #-}
+    {-# INLINABLE exprDict #-}
     type Sat Identity = Top
-    exprDict _ = Dict
+    exprDict = const Dict
 
 instance Semantic Identity
   where
+    {-# SPECIALIZE instance Semantic Identity #-}
+    {-# INLINABLE semantics #-}
     semantics Id = Sem "id" id
 
 semanticInstances ''Identity
-

--- a/src/Language/Syntactic/Constructs/Literal.hs
+++ b/src/Language/Syntactic/Constructs/Literal.hs
@@ -18,11 +18,16 @@ data Literal sig
 
 instance Constrained Literal
   where
+    {-# SPECIALIZE instance Constrained Literal #-}
+    {-# INLINABLE exprDict #-}
     type Sat Literal = Eq :/\: Show :/\: Typeable :/\: Top
     exprDict (Literal _) = Dict
 
 instance Equality Literal
   where
+    {-# SPECIALIZE instance Equality Literal #-}
+    {-# INLINABLE equal #-}
+    {-# INLINABLE exprHash #-}
     Literal a `equal` Literal b = case cast a of
         Just a' -> a'==b
         Nothing -> False
@@ -31,11 +36,15 @@ instance Equality Literal
 
 instance Render Literal
   where
+    {-# SPECIALIZE instance Render Literal #-}
+    {-# INLINABLE renderSym #-}
     renderSym (Literal a) = show a
 
-instance StringTree Literal
+instance StringTree Literal where
+  {-# SPECIALIZE instance StringTree Literal #-}
 
 instance Eval Literal
   where
+    {-# SPECIALIZE instance Eval Literal #-}
+    {-# INLINABLE evaluate #-}
     evaluate (Literal a) = a
-

--- a/src/Language/Syntactic/Constructs/Monad.hs
+++ b/src/Language/Syntactic/Constructs/Monad.hs
@@ -23,23 +23,38 @@ data MONAD m sig
 
 instance Constrained (MONAD m)
   where
+    {-# SPECIALIZE instance Constrained (MONAD m) #-}
+    {-# INLINABLE exprDict #-}
     type Sat (MONAD m) = Top
-    exprDict _ = Dict
+    exprDict = const Dict
 
 instance Monad m => Semantic (MONAD m)
   where
+    {-# SPECIALIZE instance (Monad m) => Semantic (MONAD m) #-}
+    {-# INLINABLE semantics #-}
     semantics Return = Sem "return" return
     semantics Bind   = Sem "bind"   (>>=)
     semantics Then   = Sem "then"   (>>)
     semantics When   = Sem "when"   when
 
-instance Monad m => Equality   (MONAD m) where equal      = equalDefault; exprHash = exprHashDefault
-instance Monad m => Render     (MONAD m) where renderSym  = renderSymDefault
-                                               renderArgs = renderArgsDefault
-instance Monad m => Eval       (MONAD m) where evaluate   = evaluateDefault
-instance Monad m => StringTree (MONAD m)
+instance Monad m => Equality   (MONAD m) where
+  {-# SPECIALIZE instance (Monad m) => Equality (MONAD m) #-}
+  {-# INLINABLE equal #-}
+  {-# INLINABLE exprHash #-}
+  equal = equalDefault
+  exprHash = exprHashDefault
+instance Monad m => Render     (MONAD m) where
+  {-# SPECIALIZE instance (Monad m) => Render (MONAD m) #-}
+  {-# INLINABLE renderSym #-}
+  renderSym = renderSymDefault
+instance Monad m => Eval       (MONAD m) where
+  {-# SPECIALIZE instance (Monad m) => Eval (MONAD m) #-}
+  {-# INLINABLE evaluate #-}
+  evaluate = evaluateDefault
+instance Monad m => StringTree (MONAD m) where
+  {-# SPECIALIZE instance (Monad m) => StringTree (MONAD m) #-}
 
 -- | Projection with explicit monad type
 prjMonad :: Project (MONAD m) sup => P m -> sup sig -> Maybe (MONAD m sig)
 prjMonad _ = prj
-
+{-# INLINABLE prjMonad #-}

--- a/src/Language/Syntactic/Constructs/Tuple.hs
+++ b/src/Language/Syntactic/Constructs/Tuple.hs
@@ -36,11 +36,15 @@ data Tuple sig
 
 instance Constrained Tuple
   where
+    {-# SPECIALIZE instance Constrained Tuple #-}
+    {-# INLINE exprDict #-}
     type Sat Tuple = Top
-    exprDict _ = Dict
+    exprDict = const Dict
 
 instance Semantic Tuple
   where
+    {-# SPECIALIZE instance Semantic Tuple #-}
+    {-# INLINABLE semantics #-}
     semantics Tup2  = Sem "tup2"  (,)
     semantics Tup3  = Sem "tup3"  (,,)
     semantics Tup4  = Sem "tup4"  (,,,)
@@ -238,11 +242,15 @@ data Select a
 
 instance Constrained Select
   where
+    {-# SPECIALIZE instance Constrained Select #-}
+    {-# INLINE exprDict #-}
     type Sat Select = Top
-    exprDict _ = Dict
+    exprDict = const Dict
 
 instance Semantic Select
   where
+    {-# SPECIALIZE instance Semantic Select #-}
+    {-# INLINABLE semantics #-}
     semantics Sel1 = Sem "sel1" sel1
     semantics Sel2 = Sem "sel2" sel2
     semantics Sel3 = Sem "sel3" sel3
@@ -280,4 +288,3 @@ selectPos Sel12 = 12
 selectPos Sel13 = 13
 selectPos Sel14 = 14
 selectPos Sel15 = 15
-

--- a/src/Language/Syntactic/Frontend/Monad.hs
+++ b/src/Language/Syntactic/Frontend/Monad.hs
@@ -93,8 +93,21 @@ instance ( Syntactic a, Domain a ~ dom
          ) =>
            Syntactic (Mon dom m a)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , IsHODomain dom Typeable pVar
+                            , InjectC (MONAD m) dom (m (Internal a))
+                            , Monad m
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+                            , Typeable m
+#else
+                            , Typeable1 m
+#endif
+                            , Typeable (Internal a)
+                            , pVar (Internal a)
+                            ) => Syntactic (Mon dom m a) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (Mon dom m a)   = dom
     type Internal (Mon dom m a) = m (Internal a)
     desugar = desugarMonad . fmap desugar
     sugar   = fmap sugar   . sugarMonad
-

--- a/src/Language/Syntactic/Frontend/Tuple.hs
+++ b/src/Language/Syntactic/Frontend/Tuple.hs
@@ -24,782 +24,1211 @@ instance
     ) =>
       Syntactic (a,b)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , InjectC Tuple dom
+                                ( Internal a
+                                , Internal b
+                                )
+                            , InjectC Select dom (Internal a)
+                            , InjectC Select dom (Internal b)
+                            ) => Syntactic (a,b) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b) = Domain a
     type Internal (a,b) =
         ( Internal a
         , Internal b
         )
 
-    desugar = uncurryN $ sugarSymC Tup2
+    -- desugar = uncurryN $ sugarSymC Tup2
+    desugar (a,b) = sugarSymC Tup2 a b
     sugar a =
         ( sugarSymC Sel1 a
         , sugarSymC Sel2 a
         )
 
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    ) =>
-      Syntactic (a,b,c)
-  where
-    type Domain (a,b,c) = Domain a
-    type Internal (a,b,c) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        )
-
-    desugar = uncurryN $ sugarSymC Tup3
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    ) =>
-      Syntactic (a,b,c,d)
-  where
-    type Domain (a,b,c,d) = Domain a
-    type Internal (a,b,c,d) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        )
-
-    desugar = uncurryN $ sugarSymC Tup4
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    ) =>
-      Syntactic (a,b,c,d,e)
-  where
-    type Domain (a,b,c,d,e) = Domain a
-    type Internal (a,b,c,d,e) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        )
-
-    desugar = uncurryN $ sugarSymC Tup5
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , Syntactic f, Domain f ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    , InjectC Select dom (Internal f)
-    ) =>
-      Syntactic (a,b,c,d,e,f)
-  where
-    type Domain (a,b,c,d,e,f) = Domain a
-    type Internal (a,b,c,d,e,f) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        )
-
-    desugar = uncurryN $ sugarSymC Tup6
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        , sugarSymC Sel6 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , Syntactic f, Domain f ~ dom
-    , Syntactic g, Domain g ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    , InjectC Select dom (Internal f)
-    , InjectC Select dom (Internal g)
-    ) =>
-      Syntactic (a,b,c,d,e,f,g)
-  where
-    type Domain (a,b,c,d,e,f,g) = Domain a
-    type Internal (a,b,c,d,e,f,g) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        )
-
-    desugar = uncurryN $ sugarSymC Tup7
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        , sugarSymC Sel6 a
-        , sugarSymC Sel7 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , Syntactic f, Domain f ~ dom
-    , Syntactic g, Domain g ~ dom
-    , Syntactic h, Domain h ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    , InjectC Select dom (Internal f)
-    , InjectC Select dom (Internal g)
-    , InjectC Select dom (Internal h)
-    ) =>
-      Syntactic (a,b,c,d,e,f,g,h)
-  where
-    type Domain (a,b,c,d,e,f,g,h) = Domain a
-    type Internal (a,b,c,d,e,f,g,h) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        )
-
-    desugar = uncurryN $ sugarSymC Tup8
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        , sugarSymC Sel6 a
-        , sugarSymC Sel7 a
-        , sugarSymC Sel8 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , Syntactic f, Domain f ~ dom
-    , Syntactic g, Domain g ~ dom
-    , Syntactic h, Domain h ~ dom
-    , Syntactic i, Domain i ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    , InjectC Select dom (Internal f)
-    , InjectC Select dom (Internal g)
-    , InjectC Select dom (Internal h)
-    , InjectC Select dom (Internal i)
-    ) =>
-      Syntactic (a,b,c,d,e,f,g,h,i)
-  where
-    type Domain (a,b,c,d,e,f,g,h,i) = Domain a
-    type Internal (a,b,c,d,e,f,g,h,i) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        )
-
-    desugar = uncurryN $ sugarSymC Tup9
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        , sugarSymC Sel6 a
-        , sugarSymC Sel7 a
-        , sugarSymC Sel8 a
-        , sugarSymC Sel9 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , Syntactic f, Domain f ~ dom
-    , Syntactic g, Domain g ~ dom
-    , Syntactic h, Domain h ~ dom
-    , Syntactic i, Domain i ~ dom
-    , Syntactic j, Domain j ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    , InjectC Select dom (Internal f)
-    , InjectC Select dom (Internal g)
-    , InjectC Select dom (Internal h)
-    , InjectC Select dom (Internal i)
-    , InjectC Select dom (Internal j)
-    ) =>
-      Syntactic (a,b,c,d,e,f,g,h,i,j)
-  where
-    type Domain (a,b,c,d,e,f,g,h,i,j) = Domain a
-    type Internal (a,b,c,d,e,f,g,h,i,j) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        )
-
-    desugar = uncurryN $ sugarSymC Tup10
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        , sugarSymC Sel6 a
-        , sugarSymC Sel7 a
-        , sugarSymC Sel8 a
-        , sugarSymC Sel9 a
-        , sugarSymC Sel10 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , Syntactic f, Domain f ~ dom
-    , Syntactic g, Domain g ~ dom
-    , Syntactic h, Domain h ~ dom
-    , Syntactic i, Domain i ~ dom
-    , Syntactic j, Domain j ~ dom
-    , Syntactic k, Domain k ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        , Internal k
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    , InjectC Select dom (Internal f)
-    , InjectC Select dom (Internal g)
-    , InjectC Select dom (Internal h)
-    , InjectC Select dom (Internal i)
-    , InjectC Select dom (Internal j)
-    , InjectC Select dom (Internal k)
-    ) =>
-      Syntactic (a,b,c,d,e,f,g,h,i,j,k)
-  where
-    type Domain (a,b,c,d,e,f,g,h,i,j,k) = Domain a
-    type Internal (a,b,c,d,e,f,g,h,i,j,k) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        , Internal k
-        )
-
-    desugar = uncurryN $ sugarSymC Tup11
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        , sugarSymC Sel6 a
-        , sugarSymC Sel7 a
-        , sugarSymC Sel8 a
-        , sugarSymC Sel9 a
-        , sugarSymC Sel10 a
-        , sugarSymC Sel11 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , Syntactic f, Domain f ~ dom
-    , Syntactic g, Domain g ~ dom
-    , Syntactic h, Domain h ~ dom
-    , Syntactic i, Domain i ~ dom
-    , Syntactic j, Domain j ~ dom
-    , Syntactic k, Domain k ~ dom
-    , Syntactic l, Domain l ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        , Internal k
-        , Internal l
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    , InjectC Select dom (Internal f)
-    , InjectC Select dom (Internal g)
-    , InjectC Select dom (Internal h)
-    , InjectC Select dom (Internal i)
-    , InjectC Select dom (Internal j)
-    , InjectC Select dom (Internal k)
-    , InjectC Select dom (Internal l)
-    ) =>
-      Syntactic (a,b,c,d,e,f,g,h,i,j,k,l)
-  where
-    type Domain (a,b,c,d,e,f,g,h,i,j,k,l) = Domain a
-    type Internal (a,b,c,d,e,f,g,h,i,j,k,l) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        , Internal k
-        , Internal l
-        )
-
-    desugar = uncurryN $ sugarSymC Tup12
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        , sugarSymC Sel6 a
-        , sugarSymC Sel7 a
-        , sugarSymC Sel8 a
-        , sugarSymC Sel9 a
-        , sugarSymC Sel10 a
-        , sugarSymC Sel11 a
-        , sugarSymC Sel12 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , Syntactic f, Domain f ~ dom
-    , Syntactic g, Domain g ~ dom
-    , Syntactic h, Domain h ~ dom
-    , Syntactic i, Domain i ~ dom
-    , Syntactic j, Domain j ~ dom
-    , Syntactic k, Domain k ~ dom
-    , Syntactic l, Domain l ~ dom
-    , Syntactic m, Domain m ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        , Internal k
-        , Internal l
-        , Internal m
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    , InjectC Select dom (Internal f)
-    , InjectC Select dom (Internal g)
-    , InjectC Select dom (Internal h)
-    , InjectC Select dom (Internal i)
-    , InjectC Select dom (Internal j)
-    , InjectC Select dom (Internal k)
-    , InjectC Select dom (Internal l)
-    , InjectC Select dom (Internal m)
-    ) =>
-      Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m)
-  where
-    type Domain (a,b,c,d,e,f,g,h,i,j,k,l,m) = Domain a
-    type Internal (a,b,c,d,e,f,g,h,i,j,k,l,m) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        , Internal k
-        , Internal l
-        , Internal m
-        )
-
-    desugar = uncurryN $ sugarSymC Tup13
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        , sugarSymC Sel6 a
-        , sugarSymC Sel7 a
-        , sugarSymC Sel8 a
-        , sugarSymC Sel9 a
-        , sugarSymC Sel10 a
-        , sugarSymC Sel11 a
-        , sugarSymC Sel12 a
-        , sugarSymC Sel13 a
-        )
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , Syntactic f, Domain f ~ dom
-    , Syntactic g, Domain g ~ dom
-    , Syntactic h, Domain h ~ dom
-    , Syntactic i, Domain i ~ dom
-    , Syntactic j, Domain j ~ dom
-    , Syntactic k, Domain k ~ dom
-    , Syntactic l, Domain l ~ dom
-    , Syntactic m, Domain m ~ dom
-    , Syntactic n, Domain n ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        , Internal k
-        , Internal l
-        , Internal m
-        , Internal n
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    , InjectC Select dom (Internal f)
-    , InjectC Select dom (Internal g)
-    , InjectC Select dom (Internal h)
-    , InjectC Select dom (Internal i)
-    , InjectC Select dom (Internal j)
-    , InjectC Select dom (Internal k)
-    , InjectC Select dom (Internal l)
-    , InjectC Select dom (Internal m)
-    , InjectC Select dom (Internal n)
-    ) =>
-      Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
-  where
-    type Domain (a,b,c,d,e,f,g,h,i,j,k,l,m,n) = Domain a
-    type Internal (a,b,c,d,e,f,g,h,i,j,k,l,m,n) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        , Internal k
-        , Internal l
-        , Internal m
-        , Internal n
-        )
-
-    desugar = uncurryN $ sugarSymC Tup14
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        , sugarSymC Sel6 a
-        , sugarSymC Sel7 a
-        , sugarSymC Sel8 a
-        , sugarSymC Sel9 a
-        , sugarSymC Sel10 a
-        , sugarSymC Sel11 a
-        , sugarSymC Sel12 a
-        , sugarSymC Sel13 a
-        , sugarSymC Sel14 a
-        )
-
-
-instance
-    ( Syntactic a, Domain a ~ dom
-    , Syntactic b, Domain b ~ dom
-    , Syntactic c, Domain c ~ dom
-    , Syntactic d, Domain d ~ dom
-    , Syntactic e, Domain e ~ dom
-    , Syntactic f, Domain f ~ dom
-    , Syntactic g, Domain g ~ dom
-    , Syntactic h, Domain h ~ dom
-    , Syntactic i, Domain i ~ dom
-    , Syntactic j, Domain j ~ dom
-    , Syntactic k, Domain k ~ dom
-    , Syntactic l, Domain l ~ dom
-    , Syntactic m, Domain m ~ dom
-    , Syntactic n, Domain n ~ dom
-    , Syntactic o, Domain o ~ dom
-    , InjectC Tuple dom
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        , Internal k
-        , Internal l
-        , Internal m
-        , Internal n
-        , Internal o
-        )
-    , InjectC Select dom (Internal a)
-    , InjectC Select dom (Internal b)
-    , InjectC Select dom (Internal c)
-    , InjectC Select dom (Internal d)
-    , InjectC Select dom (Internal e)
-    , InjectC Select dom (Internal f)
-    , InjectC Select dom (Internal g)
-    , InjectC Select dom (Internal h)
-    , InjectC Select dom (Internal i)
-    , InjectC Select dom (Internal j)
-    , InjectC Select dom (Internal k)
-    , InjectC Select dom (Internal l)
-    , InjectC Select dom (Internal m)
-    , InjectC Select dom (Internal n)
-    , InjectC Select dom (Internal o)
-    ) =>
-      Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
-  where
-    type Domain (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) = Domain a
-    type Internal (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) =
-        ( Internal a
-        , Internal b
-        , Internal c
-        , Internal d
-        , Internal e
-        , Internal f
-        , Internal g
-        , Internal h
-        , Internal i
-        , Internal j
-        , Internal k
-        , Internal l
-        , Internal m
-        , Internal n
-        , Internal o
-        )
-
-    desugar = uncurryN $ sugarSymC Tup15
-    sugar a =
-        ( sugarSymC Sel1 a
-        , sugarSymC Sel2 a
-        , sugarSymC Sel3 a
-        , sugarSymC Sel4 a
-        , sugarSymC Sel5 a
-        , sugarSymC Sel6 a
-        , sugarSymC Sel7 a
-        , sugarSymC Sel8 a
-        , sugarSymC Sel9 a
-        , sugarSymC Sel10 a
-        , sugarSymC Sel11 a
-        , sugarSymC Sel12 a
-        , sugarSymC Sel13 a
-        , sugarSymC Sel14 a
-        , sugarSymC Sel15 a
-        )
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     ) =>
+--       Syntactic (a,b,c)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             ) => Syntactic (a,b,c) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c) = Domain a
+--     type Internal (a,b,c) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup3
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     ) =>
+--       Syntactic (a,b,c,d)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             ) => Syntactic (a,b,c,d) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d) = Domain a
+--     type Internal (a,b,c,d) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup4
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     ) =>
+--       Syntactic (a,b,c,d,e)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             ) => Syntactic (a,b,c,d,e) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e) = Domain a
+--     type Internal (a,b,c,d,e) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup5
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , Syntactic f, Domain f ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     , InjectC Select dom (Internal f)
+--     ) =>
+--       Syntactic (a,b,c,d,e,f)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , Syntactic f, Domain f ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 , Internal f
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             , InjectC Select dom (Internal f)
+--                             ) => Syntactic (a,b,c,d,e,f) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e,f) = Domain a
+--     type Internal (a,b,c,d,e,f) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup6
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         , sugarSymC Sel6 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , Syntactic f, Domain f ~ dom
+--     , Syntactic g, Domain g ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     , InjectC Select dom (Internal f)
+--     , InjectC Select dom (Internal g)
+--     ) =>
+--       Syntactic (a,b,c,d,e,f,g)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , Syntactic f, Domain f ~ dom
+--                             , Syntactic g, Domain g ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 , Internal f
+--                                 , Internal g
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             , InjectC Select dom (Internal f)
+--                             , InjectC Select dom (Internal g)
+--                             ) => Syntactic (a,b,c,d,e,f,g) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e,f,g) = Domain a
+--     type Internal (a,b,c,d,e,f,g) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup7
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         , sugarSymC Sel6 a
+--         , sugarSymC Sel7 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , Syntactic f, Domain f ~ dom
+--     , Syntactic g, Domain g ~ dom
+--     , Syntactic h, Domain h ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     , InjectC Select dom (Internal f)
+--     , InjectC Select dom (Internal g)
+--     , InjectC Select dom (Internal h)
+--     ) =>
+--       Syntactic (a,b,c,d,e,f,g,h)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , Syntactic f, Domain f ~ dom
+--                             , Syntactic g, Domain g ~ dom
+--                             , Syntactic h, Domain h ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 , Internal f
+--                                 , Internal g
+--                                 , Internal h
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             , InjectC Select dom (Internal f)
+--                             , InjectC Select dom (Internal g)
+--                             , InjectC Select dom (Internal h)
+--                             ) => Syntactic (a,b,c,d,e,f,g,h) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e,f,g,h) = Domain a
+--     type Internal (a,b,c,d,e,f,g,h) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup8
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         , sugarSymC Sel6 a
+--         , sugarSymC Sel7 a
+--         , sugarSymC Sel8 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , Syntactic f, Domain f ~ dom
+--     , Syntactic g, Domain g ~ dom
+--     , Syntactic h, Domain h ~ dom
+--     , Syntactic i, Domain i ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     , InjectC Select dom (Internal f)
+--     , InjectC Select dom (Internal g)
+--     , InjectC Select dom (Internal h)
+--     , InjectC Select dom (Internal i)
+--     ) =>
+--       Syntactic (a,b,c,d,e,f,g,h,i)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , Syntactic f, Domain f ~ dom
+--                             , Syntactic g, Domain g ~ dom
+--                             , Syntactic h, Domain h ~ dom
+--                             , Syntactic i, Domain i ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 , Internal f
+--                                 , Internal g
+--                                 , Internal h
+--                                 , Internal i
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             , InjectC Select dom (Internal f)
+--                             , InjectC Select dom (Internal g)
+--                             , InjectC Select dom (Internal h)
+--                             , InjectC Select dom (Internal i)
+--                             ) => Syntactic (a,b,c,d,e,f,g,h,i) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e,f,g,h,i) = Domain a
+--     type Internal (a,b,c,d,e,f,g,h,i) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup9
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         , sugarSymC Sel6 a
+--         , sugarSymC Sel7 a
+--         , sugarSymC Sel8 a
+--         , sugarSymC Sel9 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , Syntactic f, Domain f ~ dom
+--     , Syntactic g, Domain g ~ dom
+--     , Syntactic h, Domain h ~ dom
+--     , Syntactic i, Domain i ~ dom
+--     , Syntactic j, Domain j ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     , InjectC Select dom (Internal f)
+--     , InjectC Select dom (Internal g)
+--     , InjectC Select dom (Internal h)
+--     , InjectC Select dom (Internal i)
+--     , InjectC Select dom (Internal j)
+--     ) =>
+--       Syntactic (a,b,c,d,e,f,g,h,i,j)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , Syntactic f, Domain f ~ dom
+--                             , Syntactic g, Domain g ~ dom
+--                             , Syntactic h, Domain h ~ dom
+--                             , Syntactic i, Domain i ~ dom
+--                             , Syntactic j, Domain j ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 , Internal f
+--                                 , Internal g
+--                                 , Internal h
+--                                 , Internal i
+--                                 , Internal j
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             , InjectC Select dom (Internal f)
+--                             , InjectC Select dom (Internal g)
+--                             , InjectC Select dom (Internal h)
+--                             , InjectC Select dom (Internal i)
+--                             , InjectC Select dom (Internal j)
+--                             ) =>
+--                               Syntactic (a,b,c,d,e,f,g,h,i,j) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e,f,g,h,i,j) = Domain a
+--     type Internal (a,b,c,d,e,f,g,h,i,j) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup10
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         , sugarSymC Sel6 a
+--         , sugarSymC Sel7 a
+--         , sugarSymC Sel8 a
+--         , sugarSymC Sel9 a
+--         , sugarSymC Sel10 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , Syntactic f, Domain f ~ dom
+--     , Syntactic g, Domain g ~ dom
+--     , Syntactic h, Domain h ~ dom
+--     , Syntactic i, Domain i ~ dom
+--     , Syntactic j, Domain j ~ dom
+--     , Syntactic k, Domain k ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         , Internal k
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     , InjectC Select dom (Internal f)
+--     , InjectC Select dom (Internal g)
+--     , InjectC Select dom (Internal h)
+--     , InjectC Select dom (Internal i)
+--     , InjectC Select dom (Internal j)
+--     , InjectC Select dom (Internal k)
+--     ) =>
+--       Syntactic (a,b,c,d,e,f,g,h,i,j,k)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , Syntactic f, Domain f ~ dom
+--                             , Syntactic g, Domain g ~ dom
+--                             , Syntactic h, Domain h ~ dom
+--                             , Syntactic i, Domain i ~ dom
+--                             , Syntactic j, Domain j ~ dom
+--                             , Syntactic k, Domain k ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 , Internal f
+--                                 , Internal g
+--                                 , Internal h
+--                                 , Internal i
+--                                 , Internal j
+--                                 , Internal k
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             , InjectC Select dom (Internal f)
+--                             , InjectC Select dom (Internal g)
+--                             , InjectC Select dom (Internal h)
+--                             , InjectC Select dom (Internal i)
+--                             , InjectC Select dom (Internal j)
+--                             , InjectC Select dom (Internal k)
+--                             ) => Syntactic (a,b,c,d,e,f,g,h,i,j,k) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e,f,g,h,i,j,k) = Domain a
+--     type Internal (a,b,c,d,e,f,g,h,i,j,k) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         , Internal k
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup11
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         , sugarSymC Sel6 a
+--         , sugarSymC Sel7 a
+--         , sugarSymC Sel8 a
+--         , sugarSymC Sel9 a
+--         , sugarSymC Sel10 a
+--         , sugarSymC Sel11 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , Syntactic f, Domain f ~ dom
+--     , Syntactic g, Domain g ~ dom
+--     , Syntactic h, Domain h ~ dom
+--     , Syntactic i, Domain i ~ dom
+--     , Syntactic j, Domain j ~ dom
+--     , Syntactic k, Domain k ~ dom
+--     , Syntactic l, Domain l ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         , Internal k
+--         , Internal l
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     , InjectC Select dom (Internal f)
+--     , InjectC Select dom (Internal g)
+--     , InjectC Select dom (Internal h)
+--     , InjectC Select dom (Internal i)
+--     , InjectC Select dom (Internal j)
+--     , InjectC Select dom (Internal k)
+--     , InjectC Select dom (Internal l)
+--     ) =>
+--       Syntactic (a,b,c,d,e,f,g,h,i,j,k,l)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , Syntactic f, Domain f ~ dom
+--                             , Syntactic g, Domain g ~ dom
+--                             , Syntactic h, Domain h ~ dom
+--                             , Syntactic i, Domain i ~ dom
+--                             , Syntactic j, Domain j ~ dom
+--                             , Syntactic k, Domain k ~ dom
+--                             , Syntactic l, Domain l ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 , Internal f
+--                                 , Internal g
+--                                 , Internal h
+--                                 , Internal i
+--                                 , Internal j
+--                                 , Internal k
+--                                 , Internal l
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             , InjectC Select dom (Internal f)
+--                             , InjectC Select dom (Internal g)
+--                             , InjectC Select dom (Internal h)
+--                             , InjectC Select dom (Internal i)
+--                             , InjectC Select dom (Internal j)
+--                             , InjectC Select dom (Internal k)
+--                             , InjectC Select dom (Internal l)
+--                             ) => Syntactic (a,b,c,d,e,f,g,h,i,j,k,l) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e,f,g,h,i,j,k,l) = Domain a
+--     type Internal (a,b,c,d,e,f,g,h,i,j,k,l) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         , Internal k
+--         , Internal l
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup12
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         , sugarSymC Sel6 a
+--         , sugarSymC Sel7 a
+--         , sugarSymC Sel8 a
+--         , sugarSymC Sel9 a
+--         , sugarSymC Sel10 a
+--         , sugarSymC Sel11 a
+--         , sugarSymC Sel12 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , Syntactic f, Domain f ~ dom
+--     , Syntactic g, Domain g ~ dom
+--     , Syntactic h, Domain h ~ dom
+--     , Syntactic i, Domain i ~ dom
+--     , Syntactic j, Domain j ~ dom
+--     , Syntactic k, Domain k ~ dom
+--     , Syntactic l, Domain l ~ dom
+--     , Syntactic m, Domain m ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         , Internal k
+--         , Internal l
+--         , Internal m
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     , InjectC Select dom (Internal f)
+--     , InjectC Select dom (Internal g)
+--     , InjectC Select dom (Internal h)
+--     , InjectC Select dom (Internal i)
+--     , InjectC Select dom (Internal j)
+--     , InjectC Select dom (Internal k)
+--     , InjectC Select dom (Internal l)
+--     , InjectC Select dom (Internal m)
+--     ) =>
+--       Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , Syntactic f, Domain f ~ dom
+--                             , Syntactic g, Domain g ~ dom
+--                             , Syntactic h, Domain h ~ dom
+--                             , Syntactic i, Domain i ~ dom
+--                             , Syntactic j, Domain j ~ dom
+--                             , Syntactic k, Domain k ~ dom
+--                             , Syntactic l, Domain l ~ dom
+--                             , Syntactic m, Domain m ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 , Internal f
+--                                 , Internal g
+--                                 , Internal h
+--                                 , Internal i
+--                                 , Internal j
+--                                 , Internal k
+--                                 , Internal l
+--                                 , Internal m
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             , InjectC Select dom (Internal f)
+--                             , InjectC Select dom (Internal g)
+--                             , InjectC Select dom (Internal h)
+--                             , InjectC Select dom (Internal i)
+--                             , InjectC Select dom (Internal j)
+--                             , InjectC Select dom (Internal k)
+--                             , InjectC Select dom (Internal l)
+--                             , InjectC Select dom (Internal m)
+--                             ) => Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e,f,g,h,i,j,k,l,m) = Domain a
+--     type Internal (a,b,c,d,e,f,g,h,i,j,k,l,m) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         , Internal k
+--         , Internal l
+--         , Internal m
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup13
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         , sugarSymC Sel6 a
+--         , sugarSymC Sel7 a
+--         , sugarSymC Sel8 a
+--         , sugarSymC Sel9 a
+--         , sugarSymC Sel10 a
+--         , sugarSymC Sel11 a
+--         , sugarSymC Sel12 a
+--         , sugarSymC Sel13 a
+--         )
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , Syntactic f, Domain f ~ dom
+--     , Syntactic g, Domain g ~ dom
+--     , Syntactic h, Domain h ~ dom
+--     , Syntactic i, Domain i ~ dom
+--     , Syntactic j, Domain j ~ dom
+--     , Syntactic k, Domain k ~ dom
+--     , Syntactic l, Domain l ~ dom
+--     , Syntactic m, Domain m ~ dom
+--     , Syntactic n, Domain n ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         , Internal k
+--         , Internal l
+--         , Internal m
+--         , Internal n
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     , InjectC Select dom (Internal f)
+--     , InjectC Select dom (Internal g)
+--     , InjectC Select dom (Internal h)
+--     , InjectC Select dom (Internal i)
+--     , InjectC Select dom (Internal j)
+--     , InjectC Select dom (Internal k)
+--     , InjectC Select dom (Internal l)
+--     , InjectC Select dom (Internal m)
+--     , InjectC Select dom (Internal n)
+--     ) =>
+--       Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , Syntactic f, Domain f ~ dom
+--                             , Syntactic g, Domain g ~ dom
+--                             , Syntactic h, Domain h ~ dom
+--                             , Syntactic i, Domain i ~ dom
+--                             , Syntactic j, Domain j ~ dom
+--                             , Syntactic k, Domain k ~ dom
+--                             , Syntactic l, Domain l ~ dom
+--                             , Syntactic m, Domain m ~ dom
+--                             , Syntactic n, Domain n ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 , Internal f
+--                                 , Internal g
+--                                 , Internal h
+--                                 , Internal i
+--                                 , Internal j
+--                                 , Internal k
+--                                 , Internal l
+--                                 , Internal m
+--                                 , Internal n
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             , InjectC Select dom (Internal f)
+--                             , InjectC Select dom (Internal g)
+--                             , InjectC Select dom (Internal h)
+--                             , InjectC Select dom (Internal i)
+--                             , InjectC Select dom (Internal j)
+--                             , InjectC Select dom (Internal k)
+--                             , InjectC Select dom (Internal l)
+--                             , InjectC Select dom (Internal m)
+--                             , InjectC Select dom (Internal n)
+--                             ) => Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m,n) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e,f,g,h,i,j,k,l,m,n) = Domain a
+--     type Internal (a,b,c,d,e,f,g,h,i,j,k,l,m,n) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         , Internal k
+--         , Internal l
+--         , Internal m
+--         , Internal n
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup14
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         , sugarSymC Sel6 a
+--         , sugarSymC Sel7 a
+--         , sugarSymC Sel8 a
+--         , sugarSymC Sel9 a
+--         , sugarSymC Sel10 a
+--         , sugarSymC Sel11 a
+--         , sugarSymC Sel12 a
+--         , sugarSymC Sel13 a
+--         , sugarSymC Sel14 a
+--         )
+--
+--
+-- instance
+--     ( Syntactic a, Domain a ~ dom
+--     , Syntactic b, Domain b ~ dom
+--     , Syntactic c, Domain c ~ dom
+--     , Syntactic d, Domain d ~ dom
+--     , Syntactic e, Domain e ~ dom
+--     , Syntactic f, Domain f ~ dom
+--     , Syntactic g, Domain g ~ dom
+--     , Syntactic h, Domain h ~ dom
+--     , Syntactic i, Domain i ~ dom
+--     , Syntactic j, Domain j ~ dom
+--     , Syntactic k, Domain k ~ dom
+--     , Syntactic l, Domain l ~ dom
+--     , Syntactic m, Domain m ~ dom
+--     , Syntactic n, Domain n ~ dom
+--     , Syntactic o, Domain o ~ dom
+--     , InjectC Tuple dom
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         , Internal k
+--         , Internal l
+--         , Internal m
+--         , Internal n
+--         , Internal o
+--         )
+--     , InjectC Select dom (Internal a)
+--     , InjectC Select dom (Internal b)
+--     , InjectC Select dom (Internal c)
+--     , InjectC Select dom (Internal d)
+--     , InjectC Select dom (Internal e)
+--     , InjectC Select dom (Internal f)
+--     , InjectC Select dom (Internal g)
+--     , InjectC Select dom (Internal h)
+--     , InjectC Select dom (Internal i)
+--     , InjectC Select dom (Internal j)
+--     , InjectC Select dom (Internal k)
+--     , InjectC Select dom (Internal l)
+--     , InjectC Select dom (Internal m)
+--     , InjectC Select dom (Internal n)
+--     , InjectC Select dom (Internal o)
+--     ) =>
+--       Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
+--   where
+--     {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+--                             , Syntactic b, Domain b ~ dom
+--                             , Syntactic c, Domain c ~ dom
+--                             , Syntactic d, Domain d ~ dom
+--                             , Syntactic e, Domain e ~ dom
+--                             , Syntactic f, Domain f ~ dom
+--                             , Syntactic g, Domain g ~ dom
+--                             , Syntactic h, Domain h ~ dom
+--                             , Syntactic i, Domain i ~ dom
+--                             , Syntactic j, Domain j ~ dom
+--                             , Syntactic k, Domain k ~ dom
+--                             , Syntactic l, Domain l ~ dom
+--                             , Syntactic m, Domain m ~ dom
+--                             , Syntactic n, Domain n ~ dom
+--                             , Syntactic o, Domain o ~ dom
+--                             , InjectC Tuple dom
+--                                 ( Internal a
+--                                 , Internal b
+--                                 , Internal c
+--                                 , Internal d
+--                                 , Internal e
+--                                 , Internal f
+--                                 , Internal g
+--                                 , Internal h
+--                                 , Internal i
+--                                 , Internal j
+--                                 , Internal k
+--                                 , Internal l
+--                                 , Internal m
+--                                 , Internal n
+--                                 , Internal o
+--                                 )
+--                             , InjectC Select dom (Internal a)
+--                             , InjectC Select dom (Internal b)
+--                             , InjectC Select dom (Internal c)
+--                             , InjectC Select dom (Internal d)
+--                             , InjectC Select dom (Internal e)
+--                             , InjectC Select dom (Internal f)
+--                             , InjectC Select dom (Internal g)
+--                             , InjectC Select dom (Internal h)
+--                             , InjectC Select dom (Internal i)
+--                             , InjectC Select dom (Internal j)
+--                             , InjectC Select dom (Internal k)
+--                             , InjectC Select dom (Internal l)
+--                             , InjectC Select dom (Internal m)
+--                             , InjectC Select dom (Internal n)
+--                             , InjectC Select dom (Internal o)
+--                             ) => Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) #-}
+--     {-# INLINABLE desugar #-}
+--     {-# INLINABLE sugar #-}
+--     type Domain (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) = Domain a
+--     type Internal (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) =
+--         ( Internal a
+--         , Internal b
+--         , Internal c
+--         , Internal d
+--         , Internal e
+--         , Internal f
+--         , Internal g
+--         , Internal h
+--         , Internal i
+--         , Internal j
+--         , Internal k
+--         , Internal l
+--         , Internal m
+--         , Internal n
+--         , Internal o
+--         )
+--
+--     desugar = uncurryN $ sugarSymC Tup15
+--     sugar a =
+--         ( sugarSymC Sel1 a
+--         , sugarSymC Sel2 a
+--         , sugarSymC Sel3 a
+--         , sugarSymC Sel4 a
+--         , sugarSymC Sel5 a
+--         , sugarSymC Sel6 a
+--         , sugarSymC Sel7 a
+--         , sugarSymC Sel8 a
+--         , sugarSymC Sel9 a
+--         , sugarSymC Sel10 a
+--         , sugarSymC Sel11 a
+--         , sugarSymC Sel12 a
+--         , sugarSymC Sel13 a
+--         , sugarSymC Sel14 a
+--         , sugarSymC Sel15 a
+--         )

--- a/src/Language/Syntactic/Frontend/TupleConstrained.hs
+++ b/src/Language/Syntactic/Frontend/TupleConstrained.hs
@@ -21,15 +21,22 @@ import Language.Syntactic.Constructs.Tuple
 -- (whichever appears first) in a domain.
 class TupleSat (dom :: * -> *) (p :: * -> Constraint) | dom -> p
 
-instance TupleSat (Tuple :|| p) p
-instance TupleSat ((Tuple :|| p) :+: dom2) p
+instance TupleSat (Tuple :|| p) p where
+  {-# SPECIALIZE instance TupleSat (Tuple :|| p) p #-}
+instance TupleSat ((Tuple :|| p) :+: dom2) p where
+  {-# SPECIALIZE instance TupleSat ((Tuple :|| p) :+: dom2) p #-}
 
-instance TupleSat (Select :|| p) p
-instance TupleSat ((Select :|| p) :+: dom2) p
+instance TupleSat (Select :|| p) p where
+  {-# SPECIALIZE instance TupleSat (Select :|| p) p #-}
+instance TupleSat ((Select :|| p) :+: dom2) p where
+  {-# SPECIALIZE instance TupleSat ((Select :|| p) :+: dom2) p #-}
 
-instance TupleSat dom p => TupleSat (dom :| q) p
-instance TupleSat dom p => TupleSat (dom :|| q) p
-instance TupleSat dom2 p => TupleSat (dom1 :+: dom2) p
+instance TupleSat dom p => TupleSat (dom :| q) p where
+  {-# SPECIALIZE instance TupleSat dom p => TupleSat (dom :| q) p #-}
+instance TupleSat dom p => TupleSat (dom :|| q) p where
+  {-# SPECIALIZE instance TupleSat dom p => TupleSat (dom :|| q) p #-}
+instance TupleSat dom2 p => TupleSat (dom1 :+: dom2) p where
+  {-# SPECIALIZE instance TupleSat dom2 p => TupleSat (dom1 :+: dom2) p #-}
 
 
 
@@ -42,6 +49,7 @@ sugarSymC' :: forall sym dom sig b c p
        )
     => sym sig -> c
 sugarSymC' s = sugarSymC (C' s :: (sym :|| p) sig)
+{-# INLINABLE sugarSymC' #-}
 
 
 
@@ -61,6 +69,21 @@ instance
     ) =>
       Syntactic (a,b)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , TupleSat dom p
+                            , p (Internal a, Internal b)
+                            , p (Internal a)
+                            , p (Internal b)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            ) => Syntactic (a,b) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b) = Domain a
     type Internal (a,b) =
         ( Internal a
@@ -96,6 +119,28 @@ instance
     ) =>
       Syntactic (a,b,c)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            ) => Syntactic (a,b,c) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c) = Domain a
     type Internal (a,b,c) =
         ( Internal a
@@ -138,6 +183,33 @@ instance
     ) =>
       Syntactic (a,b,c,d)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            ) => Syntactic (a,b,c,d) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d) = Domain a
     type Internal (a,b,c,d) =
         ( Internal a
@@ -187,6 +259,38 @@ instance
     ) =>
       Syntactic (a,b,c,d,e)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            ) => Syntactic (a,b,c,d,e) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e) = Domain a
     type Internal (a,b,c,d,e) =
         ( Internal a
@@ -243,6 +347,43 @@ instance
     ) =>
       Syntactic (a,b,c,d,e,f)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , Syntactic f, Domain f ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , p (Internal f)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            , InjectC (Select :|| p) dom (Internal f)
+                            ) => Syntactic (a,b,c,d,e,f) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e,f) = Domain a
     type Internal (a,b,c,d,e,f) =
         ( Internal a
@@ -306,6 +447,48 @@ instance
     ) =>
       Syntactic (a,b,c,d,e,f,g)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , Syntactic f, Domain f ~ dom
+                            , Syntactic g, Domain g ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , p (Internal f)
+                            , p (Internal g)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            , InjectC (Select :|| p) dom (Internal f)
+                            , InjectC (Select :|| p) dom (Internal g)
+                            ) => Syntactic (a,b,c,d,e,f,g) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e,f,g) = Domain a
     type Internal (a,b,c,d,e,f,g) =
         ( Internal a
@@ -377,6 +560,53 @@ instance
     ) =>
       Syntactic (a,b,c,d,e,f,g,h)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , Syntactic f, Domain f ~ dom
+                            , Syntactic g, Domain g ~ dom
+                            , Syntactic h, Domain h ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , p (Internal f)
+                            , p (Internal g)
+                            , p (Internal h)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            , InjectC (Select :|| p) dom (Internal f)
+                            , InjectC (Select :|| p) dom (Internal g)
+                            , InjectC (Select :|| p) dom (Internal h)
+                            ) => Syntactic (a,b,c,d,e,f,g,h) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e,f,g,h) = Domain a
     type Internal (a,b,c,d,e,f,g,h) =
         ( Internal a
@@ -455,6 +685,58 @@ instance
     ) =>
       Syntactic (a,b,c,d,e,f,g,h,i)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , Syntactic f, Domain f ~ dom
+                            , Syntactic g, Domain g ~ dom
+                            , Syntactic h, Domain h ~ dom
+                            , Syntactic i, Domain i ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , p (Internal f)
+                            , p (Internal g)
+                            , p (Internal h)
+                            , p (Internal i)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            , InjectC (Select :|| p) dom (Internal f)
+                            , InjectC (Select :|| p) dom (Internal g)
+                            , InjectC (Select :|| p) dom (Internal h)
+                            , InjectC (Select :|| p) dom (Internal i)
+                            ) => Syntactic (a,b,c,d,e,f,g,h,i) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e,f,g,h,i) = Domain a
     type Internal (a,b,c,d,e,f,g,h,i) =
         ( Internal a
@@ -540,6 +822,63 @@ instance
     ) =>
       Syntactic (a,b,c,d,e,f,g,h,i,j)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , Syntactic f, Domain f ~ dom
+                            , Syntactic g, Domain g ~ dom
+                            , Syntactic h, Domain h ~ dom
+                            , Syntactic i, Domain i ~ dom
+                            , Syntactic j, Domain j ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , p (Internal f)
+                            , p (Internal g)
+                            , p (Internal h)
+                            , p (Internal i)
+                            , p (Internal j)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            , InjectC (Select :|| p) dom (Internal f)
+                            , InjectC (Select :|| p) dom (Internal g)
+                            , InjectC (Select :|| p) dom (Internal h)
+                            , InjectC (Select :|| p) dom (Internal i)
+                            , InjectC (Select :|| p) dom (Internal j)
+                            ) => Syntactic (a,b,c,d,e,f,g,h,i,j) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e,f,g,h,i,j) = Domain a
     type Internal (a,b,c,d,e,f,g,h,i,j) =
         ( Internal a
@@ -632,6 +971,68 @@ instance
     ) =>
       Syntactic (a,b,c,d,e,f,g,h,i,j,k)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , Syntactic f, Domain f ~ dom
+                            , Syntactic g, Domain g ~ dom
+                            , Syntactic h, Domain h ~ dom
+                            , Syntactic i, Domain i ~ dom
+                            , Syntactic j, Domain j ~ dom
+                            , Syntactic k, Domain k ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                , Internal k
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , p (Internal f)
+                            , p (Internal g)
+                            , p (Internal h)
+                            , p (Internal i)
+                            , p (Internal j)
+                            , p (Internal k)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                , Internal k
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            , InjectC (Select :|| p) dom (Internal f)
+                            , InjectC (Select :|| p) dom (Internal g)
+                            , InjectC (Select :|| p) dom (Internal h)
+                            , InjectC (Select :|| p) dom (Internal i)
+                            , InjectC (Select :|| p) dom (Internal j)
+                            , InjectC (Select :|| p) dom (Internal k)
+                            ) => Syntactic (a,b,c,d,e,f,g,h,i,j,k) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e,f,g,h,i,j,k) = Domain a
     type Internal (a,b,c,d,e,f,g,h,i,j,k) =
         ( Internal a
@@ -731,6 +1132,73 @@ instance
     ) =>
       Syntactic (a,b,c,d,e,f,g,h,i,j,k,l)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , Syntactic f, Domain f ~ dom
+                            , Syntactic g, Domain g ~ dom
+                            , Syntactic h, Domain h ~ dom
+                            , Syntactic i, Domain i ~ dom
+                            , Syntactic j, Domain j ~ dom
+                            , Syntactic k, Domain k ~ dom
+                            , Syntactic l, Domain l ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                , Internal k
+                                , Internal l
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , p (Internal f)
+                            , p (Internal g)
+                            , p (Internal h)
+                            , p (Internal i)
+                            , p (Internal j)
+                            , p (Internal k)
+                            , p (Internal l)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                , Internal k
+                                , Internal l
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            , InjectC (Select :|| p) dom (Internal f)
+                            , InjectC (Select :|| p) dom (Internal g)
+                            , InjectC (Select :|| p) dom (Internal h)
+                            , InjectC (Select :|| p) dom (Internal i)
+                            , InjectC (Select :|| p) dom (Internal j)
+                            , InjectC (Select :|| p) dom (Internal k)
+                            , InjectC (Select :|| p) dom (Internal l)
+                            ) => Syntactic (a,b,c,d,e,f,g,h,i,j,k,l) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e,f,g,h,i,j,k,l) = Domain a
     type Internal (a,b,c,d,e,f,g,h,i,j,k,l) =
         ( Internal a
@@ -837,6 +1305,78 @@ instance
     ) =>
       Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , Syntactic f, Domain f ~ dom
+                            , Syntactic g, Domain g ~ dom
+                            , Syntactic h, Domain h ~ dom
+                            , Syntactic i, Domain i ~ dom
+                            , Syntactic j, Domain j ~ dom
+                            , Syntactic k, Domain k ~ dom
+                            , Syntactic l, Domain l ~ dom
+                            , Syntactic m, Domain m ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                , Internal k
+                                , Internal l
+                                , Internal m
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , p (Internal f)
+                            , p (Internal g)
+                            , p (Internal h)
+                            , p (Internal i)
+                            , p (Internal j)
+                            , p (Internal k)
+                            , p (Internal l)
+                            , p (Internal m)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                , Internal k
+                                , Internal l
+                                , Internal m
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            , InjectC (Select :|| p) dom (Internal f)
+                            , InjectC (Select :|| p) dom (Internal g)
+                            , InjectC (Select :|| p) dom (Internal h)
+                            , InjectC (Select :|| p) dom (Internal i)
+                            , InjectC (Select :|| p) dom (Internal j)
+                            , InjectC (Select :|| p) dom (Internal k)
+                            , InjectC (Select :|| p) dom (Internal l)
+                            , InjectC (Select :|| p) dom (Internal m)
+                            ) => Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e,f,g,h,i,j,k,l,m) = Domain a
     type Internal (a,b,c,d,e,f,g,h,i,j,k,l,m) =
         ( Internal a
@@ -950,6 +1490,83 @@ instance
     ) =>
       Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , Syntactic f, Domain f ~ dom
+                            , Syntactic g, Domain g ~ dom
+                            , Syntactic h, Domain h ~ dom
+                            , Syntactic i, Domain i ~ dom
+                            , Syntactic j, Domain j ~ dom
+                            , Syntactic k, Domain k ~ dom
+                            , Syntactic l, Domain l ~ dom
+                            , Syntactic m, Domain m ~ dom
+                            , Syntactic n, Domain n ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                , Internal k
+                                , Internal l
+                                , Internal m
+                                , Internal n
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , p (Internal f)
+                            , p (Internal g)
+                            , p (Internal h)
+                            , p (Internal i)
+                            , p (Internal j)
+                            , p (Internal k)
+                            , p (Internal l)
+                            , p (Internal m)
+                            , p (Internal n)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                , Internal k
+                                , Internal l
+                                , Internal m
+                                , Internal n
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            , InjectC (Select :|| p) dom (Internal f)
+                            , InjectC (Select :|| p) dom (Internal g)
+                            , InjectC (Select :|| p) dom (Internal h)
+                            , InjectC (Select :|| p) dom (Internal i)
+                            , InjectC (Select :|| p) dom (Internal j)
+                            , InjectC (Select :|| p) dom (Internal k)
+                            , InjectC (Select :|| p) dom (Internal l)
+                            , InjectC (Select :|| p) dom (Internal m)
+                            , InjectC (Select :|| p) dom (Internal n)
+                            ) => Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m,n) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e,f,g,h,i,j,k,l,m,n) = Domain a
     type Internal (a,b,c,d,e,f,g,h,i,j,k,l,m,n) =
         ( Internal a
@@ -1070,6 +1687,88 @@ instance
     ) =>
       Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , Syntactic b, Domain b ~ dom
+                            , Syntactic c, Domain c ~ dom
+                            , Syntactic d, Domain d ~ dom
+                            , Syntactic e, Domain e ~ dom
+                            , Syntactic f, Domain f ~ dom
+                            , Syntactic g, Domain g ~ dom
+                            , Syntactic h, Domain h ~ dom
+                            , Syntactic i, Domain i ~ dom
+                            , Syntactic j, Domain j ~ dom
+                            , Syntactic k, Domain k ~ dom
+                            , Syntactic l, Domain l ~ dom
+                            , Syntactic m, Domain m ~ dom
+                            , Syntactic n, Domain n ~ dom
+                            , Syntactic o, Domain o ~ dom
+                            , TupleSat dom p
+                            , p ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                , Internal k
+                                , Internal l
+                                , Internal m
+                                , Internal n
+                                , Internal o
+                                )
+                            , p (Internal a)
+                            , p (Internal b)
+                            , p (Internal c)
+                            , p (Internal d)
+                            , p (Internal e)
+                            , p (Internal f)
+                            , p (Internal g)
+                            , p (Internal h)
+                            , p (Internal i)
+                            , p (Internal j)
+                            , p (Internal k)
+                            , p (Internal l)
+                            , p (Internal m)
+                            , p (Internal n)
+                            , p (Internal o)
+                            , InjectC (Tuple :|| p) dom
+                                ( Internal a
+                                , Internal b
+                                , Internal c
+                                , Internal d
+                                , Internal e
+                                , Internal f
+                                , Internal g
+                                , Internal h
+                                , Internal i
+                                , Internal j
+                                , Internal k
+                                , Internal l
+                                , Internal m
+                                , Internal n
+                                , Internal o
+                                )
+                            , InjectC (Select :|| p) dom (Internal a)
+                            , InjectC (Select :|| p) dom (Internal b)
+                            , InjectC (Select :|| p) dom (Internal c)
+                            , InjectC (Select :|| p) dom (Internal d)
+                            , InjectC (Select :|| p) dom (Internal e)
+                            , InjectC (Select :|| p) dom (Internal f)
+                            , InjectC (Select :|| p) dom (Internal g)
+                            , InjectC (Select :|| p) dom (Internal h)
+                            , InjectC (Select :|| p) dom (Internal i)
+                            , InjectC (Select :|| p) dom (Internal j)
+                            , InjectC (Select :|| p) dom (Internal k)
+                            , InjectC (Select :|| p) dom (Internal l)
+                            , InjectC (Select :|| p) dom (Internal m)
+                            , InjectC (Select :|| p) dom (Internal n)
+                            , InjectC (Select :|| p) dom (Internal o)
+                            ) => Syntactic (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) #-}
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
     type Domain (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) = Domain a
     type Internal (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) =
         ( Internal a
@@ -1107,4 +1806,3 @@ instance
         , sugarSymC' Sel14 a
         , sugarSymC' Sel15 a
         )
-

--- a/src/Language/Syntactic/Interpretation.hs
+++ b/src/Language/Syntactic/Interpretation.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Language.Syntactic.Interpretation where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+
+import Language.Syntactic.Interpretation.Equality
+import Language.Syntactic.Interpretation.Render
+import Language.Syntactic.Interpretation.Evaluation
+
+-- | Derive instances for 'Semantic' related classes
+-- ('Equality', 'Render', 'StringTree', 'Eval')
+semanticInstances :: Name -> DecsQ
+semanticInstances n =
+    [d|
+        instance Equality $(typ) where
+          {-# SPECIALIZE instance Equality $(typ) #-}
+        instance Render $(typ) where
+          {-# SPECIALIZE instance Render $(typ) #-}
+        instance StringTree $(typ) where
+          {-# SPECIALIZE instance StringTree $(typ) #-}
+        instance Eval $(typ) where
+          {-# SPECIALIZE instance Eval $(typ) #-}
+    |]
+  where
+    typ = conT n

--- a/src/Language/Syntactic/Interpretation/Equality.hs
+++ b/src/Language/Syntactic/Interpretation/Equality.hs
@@ -23,30 +23,37 @@ class Equality expr
     -- @equal a b  ==>  exprHash a == exprHash b@
     exprHash :: expr a -> Hash
 
-
 instance Equality dom => Equality (AST dom)
   where
+    {-# SPECIALIZE instance (Equality dom) => Equality (AST dom) #-}
+    {-# INLINABLE equal #-}
     equal (Sym a)    (Sym b)    = equal a b
     equal (s1 :$ a1) (s2 :$ a2) = equal s1 s2 && equal a1 a2
     equal _ _                   = False
 
+    {-# INLINABLE exprHash #-}
     exprHash (Sym a)  = hashInt 0 `combine` exprHash a
     exprHash (s :$ a) = hashInt 1 `combine` exprHash s `combine` exprHash a
 
 instance Equality dom => Eq (AST dom a)
   where
+    {-# SPECIALIZE instance (Equality dom) => Eq (AST dom a) #-}
+    {-# INLINABLE (==) #-}
     (==) = equal
 
 instance (Equality expr1, Equality expr2) => Equality (expr1 :+: expr2)
   where
+    {-# SPECIALIZE instance (Equality expr1, Equality expr2) => Equality (expr1 :+: expr2) #-}
+    {-# INLINABLE equal #-}
     equal (InjL a) (InjL b) = equal a b
     equal (InjR a) (InjR b) = equal a b
     equal _ _               = False
 
+    {-# INLINABLE exprHash #-}
     exprHash (InjL a) = hashInt 0 `combine` exprHash a
     exprHash (InjR a) = hashInt 1 `combine` exprHash a
 
 instance (Equality expr1, Equality expr2) => Eq ((expr1 :+: expr2) a)
   where
+    {-# SPECIALIZE instance (Equality expr1, Equality expr2) => Eq ((expr1 :+: expr2) a)#-}
     (==) = equal
-

--- a/src/Language/Syntactic/Interpretation/Evaluation.hs
+++ b/src/Language/Syntactic/Interpretation/Evaluation.hs
@@ -18,11 +18,14 @@ class Eval expr
 
 instance Eval dom => Eval (AST dom)
   where
+    {-# SPECIALIZE instance (Eval dom) => Eval (AST dom) #-}
+    {-# INLINABLE evaluate #-}
     evaluate (Sym a)  = evaluate a
     evaluate (s :$ a) = evaluate s $ evaluate a
 
 instance (Eval expr1, Eval expr2) => Eval (expr1 :+: expr2)
   where
+    {-# SPECIALIZE instance (Eval expr1, Eval expr2) => Eval (expr1 :+: expr2) #-}
+    {-# INLINABLE evaluate #-}
     evaluate (InjL a) = evaluate a
     evaluate (InjR a) = evaluate a
-

--- a/src/Language/Syntactic/Interpretation/Evaluation.hs
+++ b/src/Language/Syntactic/Interpretation/Evaluation.hs
@@ -1,20 +1,34 @@
+{-# LANGUAGE DefaultSignatures #-}
+
 module Language.Syntactic.Interpretation.Evaluation where
 
 
 
 import Language.Syntactic.Syntax
+import Language.Syntactic.Interpretation.Semantics
 
 
-
--- | The denotation of a symbol with the given signature
-type family   Denotation sig
-type instance Denotation (Full a)    = a
-type instance Denotation (a :-> sig) = a -> Denotation sig
 
 class Eval expr
   where
     -- | Evaluation of expressions
     evaluate :: expr a -> Denotation a
+
+    default evaluate :: Semantic expr => expr a -> Denotation a
+    evaluate = evaluateDefault
+    {-# INLINABLE evaluate #-}
+
+-- | Default implementation of 'evaluate'
+evaluateDefault :: Semantic expr => expr a -> Denotation a
+evaluateDefault = evaluate . semantics
+{-# INLINE evaluateDefault #-}
+
+instance Eval Semantics
+  where
+    {-# SPECIALIZE instance Eval Semantics #-}
+    {-# INLINABLE evaluate #-}
+    evaluate (Sem _ a) = a
+
 
 instance Eval dom => Eval (AST dom)
   where

--- a/src/Language/Syntactic/Interpretation/Render.hs
+++ b/src/Language/Syntactic/Interpretation/Render.hs
@@ -1,5 +1,9 @@
+{-# LANGUAGE DefaultSignatures #-}
+
 module Language.Syntactic.Interpretation.Render
     ( Render (..)
+    , renderSymDefault
+    , renderArgsDefault
     , render
     , StringTree (..)
     , stringTree
@@ -15,6 +19,7 @@ import Data.Tree (Tree (..))
 import Data.Tree.View
 
 import Language.Syntactic.Syntax
+import Language.Syntactic.Interpretation.Semantics
 
 
 -- | Render a symbol as concrete syntax. A complete instance must define at least the 'renderSym'
@@ -29,6 +34,39 @@ class Render dom
     renderArgs []   a = renderSym a
     renderArgs args a = "(" ++ unwords (renderSym a : args) ++ ")"
     {-# INLINABLE renderArgs #-}
+
+    default renderSym :: Semantic dom => dom sig -> String
+    renderSym = renderSymDefault
+    {-# INLINABLE renderSym #-}
+
+-- | Default implementation of 'renderSym'
+renderSymDefault :: Semantic expr => expr a -> String
+renderSymDefault = renderSym . semantics
+{-# INLINE renderSymDefault #-}
+
+-- | Default implementation of 'renderArgs'
+renderArgsDefault :: Semantic expr => [String] -> expr a -> String
+renderArgsDefault args = renderArgs args . semantics
+{-# INLINE renderArgsDefault #-}
+
+instance Render Semantics
+  where
+    {-# SPECIALIZE instance Render Semantics #-}
+    {-# INLINABLE renderSym #-}
+    {-# INLINABLE renderArgs #-}
+    renderSym (Sem name _) = name
+    renderArgs [] (Sem name _) = name
+    renderArgs args (Sem name _)
+        | isInfix   = "(" ++ unwords [a,op,b] ++ ")"
+        | otherwise = "(" ++ unwords (name : args) ++ ")"
+      where
+        [a,b] = args
+        op    = init $ tail name
+        isInfix
+          =  not (null name)
+          && head name == '('
+          && last name == ')'
+          && length args == 2
 
 instance (Render expr1, Render expr2) => Render (expr1 :+: expr2)
   where

--- a/src/Language/Syntactic/Interpretation/Render.hs
+++ b/src/Language/Syntactic/Interpretation/Render.hs
@@ -17,7 +17,6 @@ import Data.Tree.View
 import Language.Syntactic.Syntax
 
 
-
 -- | Render a symbol as concrete syntax. A complete instance must define at least the 'renderSym'
 -- method.
 class Render dom
@@ -29,9 +28,13 @@ class Render dom
     renderArgs :: [String] -> dom sig -> String
     renderArgs []   a = renderSym a
     renderArgs args a = "(" ++ unwords (renderSym a : args) ++ ")"
+    {-# INLINABLE renderArgs #-}
 
 instance (Render expr1, Render expr2) => Render (expr1 :+: expr2)
   where
+    {-# SPECIALIZE instance (Render expr1, Render expr2) => Render (expr1 :+: expr2) #-}
+    {-# INLINABLE renderSym #-}
+    {-# INLINABLE renderArgs #-}
     renderSym (InjL a) = renderSym a
     renderSym (InjR a) = renderSym a
     renderArgs args (InjL a) = renderArgs args a
@@ -44,9 +47,11 @@ render = go []
     go :: [String] -> AST dom sig -> String
     go args (Sym a)  = renderArgs args a
     go args (s :$ a) = go (render a : args) s
+{-# INLINABLE render #-}
 
 instance Render dom => Show (ASTF dom a)
   where
+    {-# SPECIALIZE instance Render dom => Show (ASTF dom a) #-}
     show = render
 
 
@@ -57,9 +62,12 @@ class Render dom => StringTree dom
     -- | Convert a symbol to a 'Tree' given a list of argument trees
     stringTreeSym :: [Tree String] -> dom a -> Tree String
     stringTreeSym args a = Node (renderSym a) args
+    {-# INLINABLE stringTreeSym #-}
 
 instance (StringTree dom1, StringTree dom2) => StringTree (dom1 :+: dom2)
   where
+    {-# SPECIALIZE instance (StringTree dom1, StringTree dom2) => StringTree (dom1 :+: dom2) #-}
+    {-# INLINABLE stringTreeSym #-}
     stringTreeSym args (InjL a) = stringTreeSym args a
     stringTreeSym args (InjR a) = stringTreeSym args a
 
@@ -69,16 +77,19 @@ stringTree = go []
   where
     go :: [Tree String] -> AST dom sig -> Tree String
     go args (Sym a)  = stringTreeSym args a
-    go args (s :$ a) = go (stringTree a : args) s
+    go args (s :$ a) = go (go [] a : args) s
+{-# INLINABLE stringTree #-}
 
 -- | Show a syntax tree using ASCII art
 showAST :: StringTree dom => ASTF dom a -> String
 showAST = showTree . stringTree
+{-# INLINABLE showAST #-}
 
 -- | Print a syntax tree using ASCII art
 drawAST :: StringTree dom => ASTF dom a -> IO ()
 drawAST = putStrLn . showAST
+{-# INLINABLE drawAST #-}
 
 writeHtmlAST :: StringTree sym => FilePath -> ASTF sym a -> IO ()
 writeHtmlAST file = writeHtmlTree file . fmap (\n -> NodeInfo n "") . stringTree
-
+{-# INLINABLE writeHtmlAST #-}

--- a/src/Language/Syntactic/Interpretation/Semantics.hs
+++ b/src/Language/Syntactic/Interpretation/Semantics.hs
@@ -6,17 +6,7 @@ module Language.Syntactic.Interpretation.Semantics where
 
 
 
-
-import Language.Haskell.TH
-import Language.Haskell.TH.Quote
-
-import Data.Hash
-
 import Language.Syntactic.Syntax
-import Language.Syntactic.Interpretation.Equality
-import Language.Syntactic.Interpretation.Render
-import Language.Syntactic.Interpretation.Evaluation
-
 
 
 -- | A representation of a syntactic construct as a 'String' and an evaluation
@@ -32,72 +22,13 @@ data Semantics a
         -> Semantics a
 
 
-
-instance Equality Semantics
-  where
-    equal (Sem a _) (Sem b _) = a==b
-    exprHash (Sem name _)     = hash name
-
-instance Render Semantics
-  where
-    renderSym (Sem name _) = name
-    renderArgs [] (Sem name _) = name
-    renderArgs args (Sem name _)
-        | isInfix   = "(" ++ unwords [a,op,b] ++ ")"
-        | otherwise = "(" ++ unwords (name : args) ++ ")"
-      where
-        [a,b] = args
-        op    = init $ tail name
-        isInfix
-          =  not (null name)
-          && head name == '('
-          && last name == ')'
-          && length args == 2
-
-instance Eval Semantics
-  where
-    evaluate (Sem _ a) = a
-
+-- | The denotation of a symbol with the given signature
+type family   Denotation sig
+type instance Denotation (Full a)    = a
+type instance Denotation (a :-> sig) = a -> Denotation sig
 
 
 -- | Class of expressions that can be treated as constructs
 class Semantic expr
   where
     semantics :: expr a -> Semantics a
-
--- | Default implementation of 'equal'
-equalDefault :: Semantic expr => expr a -> expr b -> Bool
-equalDefault a b = equal (semantics a) (semantics b)
-
--- | Default implementation of 'exprHash'
-exprHashDefault :: Semantic expr => expr a -> Hash
-exprHashDefault = exprHash . semantics
-
--- | Default implementation of 'renderSym'
-renderSymDefault :: Semantic expr => expr a -> String
-renderSymDefault = renderSym . semantics
-
--- | Default implementation of 'renderArgs'
-renderArgsDefault :: Semantic expr => [String] -> expr a -> String
-renderArgsDefault args = renderArgs args . semantics
-
--- | Default implementation of 'evaluate'
-evaluateDefault :: Semantic expr => expr a -> Denotation a
-evaluateDefault = evaluate . semantics
-
--- | Derive instances for 'Semantic' related classes
--- ('Equality', 'Render', 'StringTree', 'Eval')
-semanticInstances :: Name -> DecsQ
-semanticInstances n =
-    [d|
-        instance Equality $(typ) where
-          equal    = equalDefault
-          exprHash = exprHashDefault
-        instance Render $(typ) where
-          renderSym  = renderSymDefault
-          renderArgs = renderArgsDefault
-        instance StringTree $(typ)
-        instance Eval $(typ) where evaluate = evaluateDefault
-    |]
-  where
-    typ = conT n

--- a/src/Language/Syntactic/Interpretation/Semantics.hs
+++ b/src/Language/Syntactic/Interpretation/Semantics.hs
@@ -6,6 +6,7 @@ module Language.Syntactic.Interpretation.Semantics where
 
 
 
+
 import Language.Haskell.TH
 import Language.Haskell.TH.Quote
 
@@ -100,4 +101,3 @@ semanticInstances n =
     |]
   where
     typ = conT n
-

--- a/src/Language/Syntactic/Sharing/CodeMotion2.hs
+++ b/src/Language/Syntactic/Sharing/CodeMotion2.hs
@@ -44,15 +44,23 @@ showNode n = "node:" ++ show n
 
 instance AlphaEq dom dom dom env => AlphaEq Node Node dom env
   where
+    {-# SPECIALIZE instance AlphaEq dom dom dom env =>
+          AlphaEq Node Node dom env #-}
+    {-# INLINABLE alphaEqSym #-}
     alphaEqSym (Node n1) _ (Node n2) _ = return (n1 == n2)
 
 instance Constrained Node
   where
+    {-# SPECIALIZE instance Constrained Node #-}
+    {-# INLINABLE exprDict #-}
     type Sat Node = Top
     exprDict _ = Dict
 
 instance Equality Node
   where
+    {-# SPECIALIZE instance Equality Node #-}
+    {-# INLINABLE equal #-}
+    {-# INLINABLE exprHash #-}
     equal (Node n1) (Node n2) = error "can't compare nodes for equality"
     exprHash (Node n)         = hash (nodeInteger n)
 
@@ -64,6 +72,8 @@ data Node a
     Node :: NodeId -> Node (Full a)
 
 instance Render Node where
+  {-# SPECIALIZE instance Render Node #-}
+  {-# INLINABLE renderSym #-}
   renderSym (Node n) = showNode n
 
 

--- a/src/Language/Syntactic/Sharing/Graph.hs
+++ b/src/Language/Syntactic/Sharing/Graph.hs
@@ -45,14 +45,19 @@ data Node a
 
 instance Constrained Node
   where
+    {-# SPECIALIZE instance Constrained Node #-}
+    {-# INLINABLE exprDict #-}
     type Sat Node = Top
     exprDict _ = Dict
 
 instance Render Node
   where
+    {-# SPECIALIZE instance Render Node #-}
+    {-# INLINABLE renderSym #-}
     renderSym (Node a) = showNode a
 
-instance StringTree Node
+instance StringTree Node where
+  {-# SPECIALIZE instance StringTree Node #-}
 
 
 
@@ -71,17 +76,26 @@ type NodeEnv dom p =
 
 instance (p ~ Sat dom) => NodeEqEnv dom (EqEnv dom p)
   where
+    {-# SPECIALIZE instance (p ~ Sat dom) => NodeEqEnv dom (EqEnv dom p) #-}
+    {-# INLINABLE prjNodeEqEnv #-}
+    {-# INLINABLE modNodeEqEnv #-}
     prjNodeEqEnv   = snd
     modNodeEqEnv f = (id *** f)
 
 instance VarEqEnv (EqEnv dom p)
   where
+    {-# SPECIALIZE instance VarEqEnv (EqEnv dom p) #-}
+    {-# INLINABLE prjVarEqEnv #-}
+    {-# INLINABLE modVarEqEnv #-}
     prjVarEqEnv   = fst
     modVarEqEnv f = (f *** id)
 
 instance (AlphaEq dom dom dom env, NodeEqEnv dom env) =>
     AlphaEq Node Node dom env
   where
+    {-# SPECIALIZE instance (AlphaEq dom dom dom env, NodeEqEnv dom env) =>
+          AlphaEq Node Node dom env #-}
+    {-# INLINABLE alphaEqSym #-}
     alphaEqSym (Node n1) Nil (Node n2) Nil
         | n1 == n2  = return True
         | otherwise = do
@@ -334,4 +348,3 @@ cse graph@(ASG top nodes n) = nubNodes $ reindexNodes (reixTab!) graph
   where
     parts   = partitionNodes graph
     reixTab = array (0,n-1) [(n,p) | (part,p) <- parts `zip` [0..], n <- part]
-

--- a/src/Language/Syntactic/Sugar.hs
+++ b/src/Language/Syntactic/Sugar.hs
@@ -23,14 +23,18 @@ class Syntactic a
 
 instance Syntactic (ASTF dom a)
   where
+    {-# SPECIALIZE instance Syntactic (ASTF dom a) #-}
     type Domain (ASTF dom a)   = dom
     type Internal (ASTF dom a) = a
     desugar = id
     sugar   = id
+    {-# INLINABLE desugar #-}
+    {-# INLINABLE sugar #-}
 
 -- | Syntactic type casting
 resugar :: (Syntactic a, Syntactic b, Domain a ~ Domain b, Internal a ~ Internal b) => a -> b
 resugar = sugar . desugar
+{-# INLINABLE resugar #-}
 
 -- | N-ary syntactic functions
 --
@@ -60,8 +64,13 @@ class SyntacticN a internal | a -> internal
 
 instance (Syntactic a, Domain a ~ dom, ia ~ AST dom (Full (Internal a))) => SyntacticN a ia
   where
+    {-# SPECIALIZE instance ( Syntactic a, Domain a ~ dom
+                            , ia ~ AST dom (Full (Internal a))
+                            ) => SyntacticN a ia #-}
     desugarN = desugar
     sugarN   = sugar
+    {-# INLINABLE desugarN #-}
+    {-# INLINABLE sugarN #-}
 
 instance
     ( Syntactic a
@@ -71,8 +80,15 @@ instance
     ) =>
       SyntacticN (a -> b) (AST dom (Full ia) -> ib)
   where
+    {-# SPECIALIZE instance ( Syntactic a
+                            , Domain a ~ dom
+                            , ia ~ Internal a
+                            , SyntacticN b ib
+                            ) => SyntacticN (a -> b) (AST dom (Full ia) -> ib) #-}
     desugarN f = desugarN . f . sugar
     sugarN f   = sugarN . f . desugar
+    {-# INLINABLE desugarN #-}
+    {-# INLINABLE sugarN #-}
 
 
 
@@ -91,6 +107,7 @@ instance
 sugarSym :: (sym :<: AST dom, ApplySym sig b dom, SyntacticN c b) =>
     sym sig -> c
 sugarSym = sugarN . appSym
+{-# INLINABLE sugarSym #-}
 
 -- | \"Sugared\" symbol application
 --
@@ -111,4 +128,4 @@ sugarSymC
        )
     => sym sig -> c
 sugarSymC = sugarN . appSymC
-
+{-# INLINABLE sugarSymC #-}

--- a/src/Language/Syntactic/Syntax.hs
+++ b/src/Language/Syntactic/Syntax.hs
@@ -28,7 +28,7 @@ module Language.Syntactic.Syntax
 
 
 #if (__GLASGOW_HASKELL__ <= 704)
-import Control.Monad.instances
+import Control.Monad.Instances ()
 #endif
 import Data.Typeable
 

--- a/src/Language/Syntactic/Syntax.hs
+++ b/src/Language/Syntactic/Syntax.hs
@@ -27,7 +27,9 @@ module Language.Syntactic.Syntax
     ) where
 
 
-
+#if (__GLASGOW_HASKELL__ <= 704)
+import Control.Monad.instances
+#endif
 import Data.Typeable
 
 import Data.PolyProxy

--- a/src/Language/Syntactic/Syntax.hs
+++ b/src/Language/Syntactic/Syntax.hs
@@ -28,7 +28,6 @@ module Language.Syntactic.Syntax
 
 
 
-import Control.Monad.Instances  -- Not needed in GHC 7.6
 import Data.Typeable
 
 import Data.PolyProxy

--- a/src/Language/Syntactic/Traversal.hs
+++ b/src/Language/Syntactic/Traversal.hs
@@ -36,7 +36,7 @@ import Language.Syntactic.Syntax
 gmapT :: forall dom
       .  (forall a . ASTF dom a -> ASTF dom a)
       -> (forall a . ASTF dom a -> ASTF dom a)
-gmapT f a = go a
+gmapT f = go
   where
     go :: forall a . AST dom a -> AST dom a
     go (s :$ a) = go s :$ f a
@@ -48,7 +48,7 @@ gmapT f a = go a
 gmapQ :: forall dom b
       .  (forall a . ASTF dom a -> b)
       -> (forall a . ASTF dom a -> [b])
-gmapQ f a = go a
+gmapQ f = go
   where
     go :: forall a . AST dom a -> [b]
     go (s :$ a) = f a : go s
@@ -79,21 +79,21 @@ infixr :*
 -- | Map a function over an 'Args' list and collect the results in an ordinary
 -- list
 listArgs :: (forall a . c (Full a) -> b) -> Args c sig -> [b]
-listArgs f Nil       = []
+listArgs _ Nil       = []
 listArgs f (a :* as) = f a : listArgs f as
 
 -- | Map a function over an 'Args' list
 mapArgs
     :: (forall a   . c1 (Full a) -> c2 (Full a))
     -> (forall sig . Args c1 sig -> Args c2 sig)
-mapArgs f Nil       = Nil
+mapArgs _ Nil       = Nil
 mapArgs f (a :* as) = f a :* mapArgs f as
 
 -- | Map an applicative function over an 'Args' list
 mapArgsA :: Applicative f
     => (forall a   . c1 (Full a) -> f (c2 (Full a)))
     -> (forall sig . Args c1 sig -> f (Args c2 sig))
-mapArgsA f Nil       = pure Nil
+mapArgsA _ Nil       = pure Nil
 mapArgsA f (a :* as) = (:*) <$> f a <*> mapArgsA f as
 
 -- | Map a monadic function over an 'Args' list
@@ -107,7 +107,7 @@ foldrArgs
     :: (forall a . c (Full a) -> b -> b)
     -> b
     -> (forall sig . Args c sig -> b)
-foldrArgs f b Nil       = b
+foldrArgs _ b Nil       = b
 foldrArgs f b (a :* as) = f a (foldrArgs f b as)
 
 -- | Apply a (partially applied) symbol to a list of argument terms
@@ -123,7 +123,7 @@ match :: forall dom a c
        )
     -> ASTF dom a
     -> c (Full a)
-match f a = go a Nil
+match f = flip go Nil
   where
     go :: (a ~ DenResult sig) => AST dom sig -> Args (AST dom) sig -> c (Full a)
     go (Sym a)  as = f a as

--- a/src/Language/Syntactic/Traversal.hs
+++ b/src/Language/Syntactic/Traversal.hs
@@ -129,6 +129,7 @@ match f = flip go Nil
     go :: (a ~ DenResult sig) => AST dom sig -> Args (AST dom) sig -> c (Full a)
     go (Sym a)  as = f a as
     go (s :$ a) as = go s (a :* as)
+{-# INLINABLE match #-}
 
 query :: forall dom a c
     .  ( forall sig . (a ~ DenResult sig) =>
@@ -145,12 +146,14 @@ simpleMatch :: forall dom a b
     -> ASTF dom a
     -> b
 simpleMatch f = getConst . match (\s -> Const . f s)
+{-# INLINABLE simpleMatch #-}
 
 -- | Fold an 'AST' using an 'Args' list to hold the results of sub-terms
 fold :: forall dom c
     .  (forall sig . dom sig -> Args c sig -> c (Full (DenResult sig)))
     -> (forall a   . ASTF dom a -> c (Full a))
 fold f = match (\s -> f s . mapArgs (fold f))
+{-# INLINABLE fold #-}
 
 -- | Simplified version of 'fold' for situations where all intermediate results
 -- have the same type
@@ -158,12 +161,14 @@ simpleFold :: forall dom b
     .  (forall sig . dom sig -> Args (Const b) sig -> b)
     -> (forall a   . ASTF dom a                    -> b)
 simpleFold f = getConst . fold (\s -> Const . f s)
+{-# INLINABLE simpleFold #-}
 
 -- | Fold an 'AST' using a list to hold the results of sub-terms
 listFold :: forall dom b
     .  (forall sig . dom sig -> [b] -> b)
     -> (forall a   . ASTF dom a     -> b)
 listFold f = simpleFold (\s -> f s . listArgs getConst)
+{-# INLINABLE listFold #-}
 
 newtype WrapAST c dom sig = WrapAST { unWrapAST :: c (AST dom sig) }
   -- Only used in the definition of 'matchTrans'
@@ -177,6 +182,7 @@ matchTrans :: forall dom dom' c a
     -> ASTF dom a
     -> c (ASTF dom' a)
 matchTrans f = unWrapAST . match (\s -> WrapAST . f s)
+{-# INLINABLE matchTrans #-}
 
 -- | Can be used to make an arbitrary type constructor indexed by @(`Full` a)@.
 -- This is useful as the type constructor parameter of 'Args'. That is, use
@@ -195,4 +201,4 @@ data WrapFull c a
 -- | Convert an 'AST' to a 'Tree'
 toTree :: forall dom a b . (forall sig . dom sig -> b) -> ASTF dom a -> Tree b
 toTree f = listFold (Node . f)
-
+{-# INLINABLE toTree #-}

--- a/src/Language/Syntactic/Traversal.hs
+++ b/src/Language/Syntactic/Traversal.hs
@@ -11,6 +11,7 @@ module Language.Syntactic.Traversal
     , mapArgsA
     , mapArgsM
     , appArgs
+    , foldrArgs
     , listFold
     , match
     , query

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -144,6 +144,10 @@ test-suite NanoFeldsparEval
   main-is: NanoFeldsparEval.hs
 
   other-modules:
+    NanoFeldspar.Core
+    NanoFeldspar.Extra
+    NanoFeldspar.Test
+    NanoFeldspar.Vector
 
   default-language: Haskell2010
 
@@ -178,6 +182,10 @@ test-suite NanoFeldsparEval2
   main-is: NanoFeldsparEval2.hs
 
   other-modules:
+    NanoFeldspar.Core
+    NanoFeldspar.Extra
+    NanoFeldspar.Test
+    NanoFeldspar.Vector
 
   default-language: Haskell2010
 
@@ -210,6 +218,12 @@ test-suite NanoFeldsparTree
   hs-source-dirs: tests examples
 
   main-is: NanoFeldsparTree.hs
+
+  other-modules:
+    NanoFeldspar.Core
+    NanoFeldspar.Extra
+    NanoFeldspar.Test
+    NanoFeldspar.Vector
 
   default-language: Haskell2010
 

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -1,5 +1,5 @@
 Name:           syntactic
-Version:        1.15.1
+Version:        1.16
 Synopsis:       Generic abstract syntax, and utilities for embedded languages
 Description:    This library provides:
                 .

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -71,6 +71,7 @@ library
     Language.Syntactic.Traversal
     Language.Syntactic.Constraint
     Language.Syntactic.Sugar
+    Language.Syntactic.Interpretation
     Language.Syntactic.Interpretation.Equality
     Language.Syntactic.Interpretation.Evaluation
     Language.Syntactic.Interpretation.Render

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -137,8 +137,6 @@ library
     OverlappingInstances
     UndecidableInstances
 
-  ghc-options: -O
-
 test-suite NanoFeldsparEval
   type: exitcode-stdio-1.0
 

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -136,6 +136,8 @@ library
     OverlappingInstances
     UndecidableInstances
 
+  ghc-options: -O
+
 test-suite NanoFeldsparEval
   type: exitcode-stdio-1.0
 


### PR DESCRIPTION
This PR adds `SPECIALIZE` pragmas to most (all) class instances.

With these instances most of the type level computations on the `syntactic` sum-types can be performed at compile time.

The only remaining constructs that do not specialize completely are `Tuple` and `Select`.