### PR TITLE
Remove TH dependency

### DIFF
--- a/benchmarks/JoiningTypes.hs
+++ b/benchmarks/JoiningTypes.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module JoiningTypes (main) where
 
 import Criterion.Main
@@ -39,7 +37,8 @@ instance Render Expr1 where
   renderSym (EEq)   = "EEq"
   renderSym (EIf)   = "EIf"
 
-interpretationInstances ''Expr1
+instance Equality   Expr1
+instance StringTree Expr1
 
 instance Eval Expr1 where
   evalSym (EI n)  = n
@@ -91,8 +90,10 @@ instance Render ExprB where
   renderSym (EEqJ)   = "EEq"
   renderSym (EIfJ)   = "EIf"
 
-interpretationInstances ''ExprI
-interpretationInstances ''ExprB
+instance Equality   ExprI
+instance StringTree ExprI
+instance Equality   ExprB
+instance StringTree ExprB
 
 instance Eval ExprI where
   evalSym (EIJ n) = n
@@ -158,11 +159,14 @@ instance Render Expr4J4 where
 instance Render Expr4J5 where
   renderSym (E4JIf)   = "EIf"
 
-interpretationInstances ''Expr4J1
-interpretationInstances ''Expr4J2
-interpretationInstances ''Expr4J3
-interpretationInstances ''Expr4J4
-interpretationInstances ''Expr4J5
+instance Equality   Expr4J1
+instance StringTree Expr4J1
+instance Equality   Expr4J2
+instance StringTree Expr4J2
+instance Equality   Expr4J3
+instance StringTree Expr4J3
+instance Equality   Expr4J5
+instance StringTree Expr4J5
 
 instance Eval Expr4J1 where
   evalSym (E4JI n)  = n

--- a/benchmarks/Normal.hs
+++ b/benchmarks/Normal.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Normal (main) where
 
 import Criterion.Main
@@ -110,7 +108,8 @@ instance Render ExprS where
   renderSym EEq    = "EEq"
   renderSym EIf    = "EIf"
 
-interpretationInstances ''ExprS
+instance Equality   ExprS
+instance StringTree ExprS
 
 instance Eval ExprS where
   evalSym (EI n) = n

--- a/benchmarks/WithArity.hs
+++ b/benchmarks/WithArity.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module WithArity (main) where
 
 import Criterion.Main
@@ -104,7 +102,8 @@ instance Render T
     renderSym T5     = "T5"
     renderSym T10    = "T10"
 
-interpretationInstances ''T
+instance Equality   T
+instance StringTree T
 
 instance Eval T
   where

--- a/examples/NanoFeldspar.hs
+++ b/examples/NanoFeldspar.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -68,7 +67,8 @@ instance Render Arithmetic
     renderSym Mul = "(*)"
     renderArgs = renderArgsSmart
 
-interpretationInstances ''Arithmetic
+instance Equality   Arithmetic
+instance StringTree Arithmetic
 
 instance Eval Arithmetic
   where
@@ -90,7 +90,8 @@ instance Render Parallel
   where
     renderSym Parallel = "parallel"
 
-interpretationInstances ''Parallel
+instance Equality   Parallel
+instance StringTree Parallel
 
 instance Eval Parallel
   where
@@ -110,7 +111,8 @@ instance Render ForLoop
   where
     renderSym ForLoop = "forLoop"
 
-interpretationInstances ''ForLoop
+instance Equality   ForLoop
+instance StringTree ForLoop
 
 instance Eval ForLoop
   where

--- a/src/Language/Syntactic/Functional/Tuple.hs
+++ b/src/Language/Syntactic/Functional/Tuple.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 -- | Construction and elimination of tuples
 
 module Language.Syntactic.Functional.Tuple where
@@ -118,7 +116,8 @@ instance Render Tuple
     renderSym Sel4 = "sel4"
     renderArgs = renderArgsSmart
 
-interpretationInstances ''Tuple
+instance Equality   Tuple
+instance StringTree Tuple
 
 instance Eval Tuple
   where

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -72,7 +72,6 @@ library
     deepseq,
     mtl >= 2 && < 3,
     tagged,
-    template-haskell,
     tree-view
 
   hs-source-dirs: src
@@ -97,7 +96,6 @@ library
 
   other-extensions:
     OverlappingInstances
-    TemplateHaskell
     UndecidableInstances
 
 test-suite examples

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -71,8 +71,9 @@ library
     data-hash,
     deepseq,
     mtl >= 2 && < 3,
-    tagged,
     tree-view
+  if impl(ghc < 7.8)
+    build-depends: tagged
 
   hs-source-dirs: src
 

--- a/tests/MonadTests.hs
+++ b/tests/MonadTests.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module MonadTests where
 

--- a/tests/WellScopedTests.hs
+++ b/tests/WellScopedTests.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module WellScopedTests where
 


### PR DESCRIPTION
For GHC <7.8, there's still an implicit dependency on TH from `tagged` however.