### PR TITLE
Merge Full/:-> into a single type

### DIFF
--- a/examples/NanoFeldspar.hs
+++ b/examples/NanoFeldspar.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DataKinds #-}
 
 {-# OPTIONS_GHC -fno-warn-missing-methods #-}
 

--- a/examples/WellScoped.hs
+++ b/examples/WellScoped.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
+
 
 {-# OPTIONS_GHC -fno-warn-missing-methods #-}
 

--- a/src/Language/Syntactic/Functional.hs
+++ b/src/Language/Syntactic/Functional.hs
@@ -642,13 +642,13 @@ alphaEq = alphaEq' []
 ----------------------------------------------------------------------------------------------------
 
 -- | Semantic function type of the given symbol signature
-type family Denotation :: Sig Type -> Type where
+type family Denotation sig where
   Denotation (Full a)    = a
   Denotation (a :-> sig) = a -> Denotation sig
 
 class Eval s
-  where
-    evalSym :: s (sig :: Sig Type -> Type) -> Denotation sig
+  where    
+    evalSym :: s sig -> Denotation sig
 
 instance (Eval s, Eval t) => Eval (s :+: t)
   where

--- a/src/Language/Syntactic/Functional.hs
+++ b/src/Language/Syntactic/Functional.hs
@@ -642,12 +642,12 @@ alphaEq = alphaEq' []
 ----------------------------------------------------------------------------------------------------
 
 -- | Semantic function type of the given symbol signature
-type family Denotation sig where
+type family Denotation (sig :: Sig Type) where
   Denotation (Full a)    = a
   Denotation (a :-> sig) = a -> Denotation sig
 
-class Eval s
-  where    
+class Eval (s :: Sig Type -> Type)
+  where
     evalSym :: s sig -> Denotation sig
 
 instance (Eval s, Eval t) => Eval (s :+: t)

--- a/src/Language/Syntactic/Functional.hs
+++ b/src/Language/Syntactic/Functional.hs
@@ -87,7 +87,6 @@ import Data.Tree
 import Data.Hash (hashInt)
 
 
-import Data.Kind (Type)
 import Language.Syntactic
 
 
@@ -642,11 +641,11 @@ alphaEq = alphaEq' []
 ----------------------------------------------------------------------------------------------------
 
 -- | Semantic function type of the given symbol signature
-type family Denotation (sig :: Sig Type) where
+type family Denotation (sig :: Sig *) where
   Denotation (Full a)    = a
   Denotation (a :-> sig) = a -> Denotation sig
 
-class Eval (s :: Sig Type -> Type)
+class Eval (s :: Sig * -> *)
   where
     evalSym :: s sig -> Denotation sig
 
@@ -695,7 +694,7 @@ evalDen = go
 -- to
 --
 -- > m a -> m b -> m c
-type family   DenotationM (m :: Type -> Type) sig where
+type family   DenotationM (m :: * -> *) sig where
   DenotationM m (Full a)    = m a
   DenotationM m (a :-> sig) = m a -> DenotationM m sig
 

--- a/src/Language/Syntactic/Functional.hs
+++ b/src/Language/Syntactic/Functional.hs
@@ -86,6 +86,8 @@ import Data.Tree
 
 import Data.Hash (hashInt)
 
+
+import Data.Kind (Type)
 import Language.Syntactic
 
 
@@ -640,13 +642,13 @@ alphaEq = alphaEq' []
 ----------------------------------------------------------------------------------------------------
 
 -- | Semantic function type of the given symbol signature
-type family   Denotation sig
-type instance Denotation (Full a)    = a
-type instance Denotation (a :-> sig) = a -> Denotation sig
+type family Denotation :: Sig Type -> Type where
+  Denotation (Full a)    = a
+  Denotation (a :-> sig) = a -> Denotation sig
 
 class Eval s
   where
-    evalSym :: s sig -> Denotation sig
+    evalSym :: s (sig :: Sig Type -> Type) -> Denotation sig
 
 instance (Eval s, Eval t) => Eval (s :+: t)
   where
@@ -693,9 +695,9 @@ evalDen = go
 -- to
 --
 -- > m a -> m b -> m c
-type family   DenotationM (m :: * -> *) sig
-type instance DenotationM m (Full a)    = m a
-type instance DenotationM m (a :-> sig) = m a -> DenotationM m sig
+type family   DenotationM (m :: Type -> Type) sig where
+  DenotationM m (Full a)    = m a
+  DenotationM m (a :-> sig) = m a -> DenotationM m sig
 
 -- | Lift a 'Denotation' to 'DenotationM'
 liftDenotationM :: forall m sig proxy1 proxy2 . Monad m =>
@@ -782,4 +784,3 @@ evalOpen env a = runReader (compile Proxy a) env
 -- (Note that there is no guarantee that the term is actually closed.)
 evalClosed :: EvalEnv sym RunEnv => ASTF sym a -> a
 evalClosed a = runReader (compile (Proxy :: Proxy RunEnv) a) []
-

--- a/src/Language/Syntactic/Functional/WellScoped.hs
+++ b/src/Language/Syntactic/Functional/WellScoped.hs
@@ -100,12 +100,12 @@ evalClosedWS = evalOpenWS ()
 -- to
 --
 -- > Reader env a :-> Reader env b :-> Full (Reader env c)
-type family   LiftReader env sig
-type instance LiftReader env (Full a)    = Full (Reader env a)
-type instance LiftReader env (a :-> sig) = Reader env a :-> LiftReader env sig
+type family   LiftReader env sig where
+  LiftReader env (Full a)    = Full (Reader env a)
+  LiftReader env (a :-> sig) = Reader env a :-> LiftReader env sig
 
-type family UnReader a
-type instance UnReader (Reader e a) = a
+type family UnReader a where
+  UnReader (Reader e a) = a
 
 -- | Mapping from a symbol signature
 --
@@ -114,9 +114,9 @@ type instance UnReader (Reader e a) = a
 -- to
 --
 -- > a :-> b :-> Full c
-type family   LowerReader sig
-type instance LowerReader (Full a)    = Full (UnReader a)
-type instance LowerReader (a :-> sig) = UnReader a :-> LowerReader sig
+type family   LowerReader sig where
+  LowerReader (Full a)    = Full (UnReader a)
+  LowerReader (a :-> sig) = UnReader a :-> LowerReader sig
 
 -- | Wrap a symbol to give it a 'LiftReader' signature
 data ReaderSym sym sig
@@ -173,4 +173,3 @@ smartWS :: forall sig sig' bsym f sub sup env a
        )
     => sub sig -> f
 smartWS s = smartSym' $ InjR $ ReaderSym (Proxy :: Proxy env) $ inj s
-

--- a/src/Language/Syntactic/Sugar.hs
+++ b/src/Language/Syntactic/Sugar.hs
@@ -19,7 +19,6 @@
 module Language.Syntactic.Sugar where
 
 
-import Data.Kind (Type)
 import Data.Typeable
 
 import Language.Syntactic.Syntax
@@ -30,19 +29,19 @@ import Language.Syntactic.Syntax
 -- as @a@.
 class Syntactic a
   where
-    type Domain a :: Sig Type -> Type
+    type Domain a :: Sig * -> *
     type Internal a
     desugar :: a -> ASTF (Domain a) (Internal a)
     sugar   :: ASTF (Domain a) (Internal a) -> a
 
-instance Syntactic (ASTF (sym :: Sig Type -> Type) a)
+instance Syntactic (ASTF (sym :: Sig * -> *) a)
   where
     type Domain (ASTF sym a)   = sym
     type Internal (ASTF sym a) = a
     desugar = id
     sugar   = id
 
-instance Syntactic (ASTFull (sym :: Sig Type -> Type) a)
+instance Syntactic (ASTFull (sym :: Sig * -> *) a)
   where
     type Domain (ASTFull sym a)   = sym
     type Internal (ASTFull sym a) = a

--- a/src/Language/Syntactic/Sugar.hs
+++ b/src/Language/Syntactic/Sugar.hs
@@ -32,17 +32,17 @@ class Syntactic a
   where
     type Domain a :: Sig Type -> Type
     type Internal a
-    desugar :: a -> ASTFF (Domain a) (Internal a)
-    sugar   :: ASTFF (Domain a) (Internal a) -> a
+    desugar :: a -> ASTF (Domain a) (Internal a)
+    sugar   :: ASTF (Domain a) (Internal a) -> a
 
-instance Syntactic (ASTFF sym a)
+instance Syntactic (ASTF (sym :: Sig Type -> Type) a)
   where
-    type Domain (ASTFF sym a)   = sym
-    type Internal (ASTFF sym a) = a
+    type Domain (ASTF sym a)   = sym
+    type Internal (ASTF sym a) = a
     desugar = id
     sugar   = id
 
-instance Syntactic (ASTFull sym a)
+instance Syntactic (ASTFull (sym :: Sig Type -> Type) a)
   where
     type Domain (ASTFull sym a)   = sym
     type Internal (ASTFull sym a) = a

--- a/src/Language/Syntactic/Sugar.hs
+++ b/src/Language/Syntactic/Sugar.hs
@@ -19,7 +19,7 @@
 module Language.Syntactic.Sugar where
 
 
-
+import Data.Kind (Type)
 import Data.Typeable
 
 import Language.Syntactic.Syntax
@@ -30,15 +30,15 @@ import Language.Syntactic.Syntax
 -- as @a@.
 class Syntactic a
   where
-    type Domain a :: * -> *
+    type Domain a :: Sig Type -> Type
     type Internal a
-    desugar :: a -> ASTF (Domain a) (Internal a)
-    sugar   :: ASTF (Domain a) (Internal a) -> a
+    desugar :: a -> ASTFF (Domain a) (Internal a)
+    sugar   :: ASTFF (Domain a) (Internal a) -> a
 
-instance Syntactic (ASTF sym a)
+instance Syntactic (ASTFF sym a)
   where
-    type Domain (ASTF sym a)   = sym
-    type Internal (ASTF sym a) = a
+    type Domain (ASTFF sym a)   = sym
+    type Internal (ASTFF sym a) = a
     desugar = id
     sugar   = id
 
@@ -145,4 +145,3 @@ sugarSymTyped
        )
     => sub sig -> f
 sugarSymTyped = sugarN . smartSymTyped
-

--- a/src/Language/Syntactic/Syntax.hs
+++ b/src/Language/Syntactic/Syntax.hs
@@ -92,14 +92,11 @@ infixl 1 :$
 -- | Fully applied abstract syntax tree
 type ASTF sym a = AST sym (Full a)
 
-newtype ASTFull sym a = ASTFull {unASTFull :: ASTF sym a}
-
-
 -- | Fully applied abstract syntax tree
 --
 -- This type is like 'AST', but being a newtype, it is a proper type constructor
 -- that can be partially applied.
---newtype ASTFull sym a = ASTFull {unASTFull :: ASTF sym a}
+newtype ASTFull sym a = ASTFull {unASTFull :: ASTF sym a}
 
 -- instance Functor sym => Functor (AST sym)
 --   where

--- a/src/Language/Syntactic/Syntax.hs
+++ b/src/Language/Syntactic/Syntax.hs
@@ -20,7 +20,6 @@ module Language.Syntactic.Syntax
     ( -- * Syntax trees
       AST (..)
     , ASTF
-    , ASTFF
     , ASTFull (..)
     , Sig (..)
     , SigRep (..)
@@ -93,8 +92,7 @@ infixl 1 :$
 -- | Fully applied abstract syntax tree
 type ASTF sym a = AST sym (Full a)
 
-type ASTFF (sym :: Sig Type -> Type) (a :: Type) = AST sym (Full a)
-newtype ASTFull sym a = ASTFull {unASTFull :: ASTFF sym a}
+newtype ASTFull sym a = ASTFull {unASTFull :: ASTF sym a}
 
 
 -- | Fully applied abstract syntax tree
@@ -319,7 +317,7 @@ smartSymTyped = smartSym' . Typed . inj
 -- lists (e.g. to avoid overlapping instances):
 --
 -- > (A :+: B :+: Empty)
-data Empty :: Type -> Type
+data Empty :: k -> Type
 
 
 

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -162,6 +162,7 @@ benchmark syntactic-bench
   default-language: Haskell2010
 
   default-extensions:
+    DataKinds
     FlexibleInstances
     GADTs
     MultiParamTypeClasses

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -117,8 +117,7 @@ library
     ScopedTypeVariables
     TypeFamilies
     TypeOperators
-    TypeInType
-
+    
 
 
   other-extensions:

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -100,6 +100,8 @@ library
   default-language: Haskell2010
 
   default-extensions:
+    DataKinds
+    PolyKinds
     DefaultSignatures
     DeriveDataTypeable
     DeriveFunctor
@@ -115,6 +117,9 @@ library
     ScopedTypeVariables
     TypeFamilies
     TypeOperators
+    TypeInType
+
+
 
   other-extensions:
     OverlappingInstances
@@ -165,4 +170,3 @@ benchmark syntactic-bench
 
   other-extensions:
     TemplateHaskell
-

--- a/tests/AlgorithmTests.hs
+++ b/tests/AlgorithmTests.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
 
 module AlgorithmTests where
 

--- a/tests/TH.hs
+++ b/tests/TH.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
 
 module TH where
 


### PR DESCRIPTION
For your interest, this seems to compile with minimal changes. I've left alone classes like Syntactic for the most part, and simply restricted the kind where necessary to Sig Type -> Type, for example in the eval class, where the AST data type itself is still kind polymorphic.

The only casualty is Functor (AST sym) which I guess is now some other type of functor potentially? Any ideas there?

