### PR TITLE
Make syntactic 1.x compatible with GHC 8.0.2

### DIFF
--- a/src/Language/Syntactic/Constraint.hs
+++ b/src/Language/Syntactic/Constraint.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE OverlappingInstances #-}
 #endif
 {-# LANGUAGE UndecidableInstances #-}
+#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 800)
+{-# LANGUAGE UndecidableSuperClasses #-}
+#endif
 
 
 -- | Type-constrained syntax trees

--- a/src/Language/Syntactic/Constructs/Binding/Optimize.hs
+++ b/src/Language/Syntactic/Constructs/Binding/Optimize.hs
@@ -115,7 +115,7 @@ instance Optimize Empty
   where
     {-# SPECIALIZE instance Optimize Empty #-}
     {-# INLINABLE optimizeSym #-}
-    optimizeSym = error "Not implemented: optimizeSym for Empty"
+    optimizeSym _ _ _ _ = error "Not implemented: optimizeSym for Empty"
 
 instance Optimize dom => Optimize (SubConstr1 c dom p)
   where

--- a/src/Language/Syntactic/Constructs/Decoration.hs
+++ b/src/Language/Syntactic/Constructs/Decoration.hs
@@ -136,11 +136,11 @@ drawDecorWith showInfo = putStrLn . showDecorWith showInfo
 writeHtmlDecorWith :: forall info sym a. (StringTree sym)
                    => (forall sig. info sig -> String)
                    -> FilePath -> ASTF (Decor info sym) a -> IO ()
-writeHtmlDecorWith showInfo file = writeHtmlTree file . mkTree []
+writeHtmlDecorWith showInfo file = writeHtmlTree Nothing file . mkTree []
   where
     mkTree :: [Tree NodeInfo] -> AST (Decor info sym) sig -> Tree NodeInfo
     mkTree args (f :$ a) = mkTree (mkTree [] a : args) f
-    mkTree args (Sym (Decor info expr)) = Node (NodeInfo (renderSym expr) (showInfo info)) args
+    mkTree args (Sym (Decor info expr)) = Node (NodeInfo InitiallyExpanded (renderSym expr) (showInfo info)) args
 
 -- | Strip decorations from an 'AST'
 stripDecor :: AST (Decor info dom) sig -> AST dom sig

--- a/src/Language/Syntactic/Interpretation/Render.hs
+++ b/src/Language/Syntactic/Interpretation/Render.hs
@@ -128,5 +128,5 @@ drawAST = putStrLn . showAST
 {-# INLINABLE drawAST #-}
 
 writeHtmlAST :: StringTree sym => FilePath -> ASTF sym a -> IO ()
-writeHtmlAST file = writeHtmlTree file . fmap (\n -> NodeInfo n "") . stringTree
+writeHtmlAST file = writeHtmlTree Nothing file . fmap (\n -> NodeInfo InitiallyExpanded n "") . stringTree
 {-# INLINABLE writeHtmlAST #-}

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -101,7 +101,7 @@ library
 
   build-depends:
     array,
-    base >= 4 && < 4.9,
+    base >= 4 && < 5.9,
     containers,
     constraints,
     data-hash,
@@ -109,7 +109,7 @@ library
     mtl >= 2 && < 3,
     template-haskell,
     transformers >= 0.2,
-    tree-view,
+    tree-view >= 0.5,
     tuple >= 0.2
 
   hs-source-dirs: src


### PR DESCRIPTION
Ensure that Syntactic 1.x can be built with GHC 8.0.2.
This entails allowing some newer packages (in particular base)
and some API changes against 'tree-view' as well as adaptation
to GHC type checker evolution.