### PR TITLE
Fix Project prj: catch-all was causing universal Nothing results.

### DIFF
--- a/examples/NanoFeldsparComp.hs
+++ b/examples/NanoFeldsparComp.hs
@@ -99,7 +99,7 @@ confiscate = censor (const mempty) . listen
 
 compileExp :: ASTF Dom a -> CodeGen Exp
 compileExp var
-    | Just (Var v) <- prj var = return (varNameE v)
+    | Just (VarT v) <- prj var = return (varNameE v)
 compileExp (lett :$ a :$ (lam :$ body))
     | Just (Let _)  <- prj lett
     , Just (LamT v) <- prj lam

--- a/src/Language/Syntactic/Syntax.hs
+++ b/src/Language/Syntactic/Syntax.hs
@@ -246,10 +246,6 @@ instance {-# OVERLAPPING #-} Project sym1 sym3 => Project sym1 (sym2 :+: sym3)
     prj (InjR a) = prj a
     prj _        = Nothing
 
--- | If @sub@ is not in @sup@, 'prj' always returns 'Nothing'.
-instance Project sub sup
-  where
-    prj _ = Nothing
 
 -- | Symbol injection
 --

--- a/syntactic.cabal
+++ b/syntactic.cabal
@@ -127,6 +127,17 @@ test-suite examples
 
   main-is: Tests.hs
 
+  other-modules: AlgorithmTests
+                 Monad
+                 MonadTests
+                 NanoFeldspar
+                 NanoFeldsparComp
+                 NanoFeldsparTests
+                 SyntaxTests
+                 TH
+                 WellScoped
+                 WellScopedTests
+
   default-language: Haskell2010
 
   build-depends:
@@ -137,6 +148,7 @@ test-suite examples
     QuickCheck,
     tagged,
     tasty,
+    tasty-hunit,
     tasty-golden,
     tasty-quickcheck,
     tasty-th,

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -4,10 +4,12 @@ import qualified AlgorithmTests
 import qualified NanoFeldsparTests
 import qualified WellScopedTests
 import qualified MonadTests
+import qualified SyntaxTests
 import qualified TH
 
 tests = testGroup "AllTests"
-    [ AlgorithmTests.tests
+    [ SyntaxTests.tests
+    , AlgorithmTests.tests
     , NanoFeldsparTests.tests
     , WellScopedTests.tests
     , MonadTests.tests


### PR DESCRIPTION
The addition of the catch-all for
`Project` (https://github.com/emilaxelsson/syntactic/commit/9b1ddf2e)
causes `prj` to always return `Nothing` because the catch-all is seen
as a substitution instance for the `:+:` composition instances.

Added explicit unit tests to validate `prj` functionality.